### PR TITLE
READMD.md's Usage Section Lists Incorrect Login Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ yarn global add @athrd/cli
 Authenticate and share your threads:
 
 ```bash
-athrd login
+athrd auth
 athrd share
 ```
 


### PR DESCRIPTION
The readme documents the wrong login command: `athrd login`, it should be `athrd auth`. This corrects it.
