### PR TITLE
feat: use GitHub Actions for PR athrd link sync

### DIFF
--- a/.github/workflows/athrd-pr-links.yml
+++ b/.github/workflows/athrd-pr-links.yml
@@ -1,0 +1,91 @@
+name: Sync Athrd Links In PR Body
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  sync-athrd-links:
+    if: github.event.pull_request.state != 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync athrd links block in PR body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const START = "<!-- athrd-links:start -->";
+            const END = "<!-- athrd-links:end -->";
+            const LINK_REGEX = /https:\/\/athrd\.com\/[^\s)>\]]+/g;
+            const TRAILING_PUNCTUATION = /[.,);\]]+$/;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const currentBody = context.payload.pull_request.body ?? "";
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            const links = [
+              ...new Set(
+                commits.flatMap((commit) => {
+                  const matches = commit.commit.message.match(LINK_REGEX) ?? [];
+                  return matches.map((url) => url.replace(TRAILING_PUNCTUATION, ""));
+                }),
+              ),
+            ];
+
+            const renderSection = (urls) => {
+              const rows = urls.map((url) => `- ${url}`).join("\n");
+              return `${START}\n## Athrd links\n${rows}\n${END}`;
+            };
+
+            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const sectionPattern = new RegExp(
+              `${escapeRegex(START)}[\\s\\S]*?${escapeRegex(END)}\\n?`,
+              "m",
+            );
+
+            let nextBody = currentBody;
+
+            if (links.length === 0) {
+              nextBody = currentBody
+                .replace(sectionPattern, "")
+                .replace(/\n{3,}/g, "\n\n")
+                .trimEnd();
+            } else {
+              const section = renderSection(links);
+              if (sectionPattern.test(currentBody)) {
+                nextBody = currentBody
+                  .replace(sectionPattern, `${section}\n`)
+                  .replace(/\n{3,}/g, "\n\n")
+                  .trimEnd();
+              } else if (currentBody.trim().length === 0) {
+                nextBody = section;
+              } else {
+                nextBody = `${currentBody.trimEnd()}\n\n${section}`;
+              }
+            }
+
+            if (nextBody === currentBody) {
+              core.info("PR body already up to date; skipping update.");
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              body: nextBody,
+            });
+
+            core.info(`Updated PR #${pullNumber} with ${links.length} unique athrd link(s).`);

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /.pnp
 .pnp.js
 apps/web/node_modules
-apps/github-pr-app/node_modules
 
 # testing
 /coverage
@@ -29,7 +28,6 @@ next-env.d.ts
 # production
 /build
 /dist
-/apps/github-pr-app/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -59,6 +59,39 @@ athrd auth
 athrd share
 ```
 
+### GitHub Action: auto-append athrd links to PRs
+
+If you want repo-owned automation (no GitHub App install), add this workflow to the target repository:
+
+```yaml
+name: Sync Athrd Links In PR Body
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  sync-athrd-links:
+    if: github.event.pull_request.state != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            // See .github/workflows/athrd-pr-links.yml in this repo for full script.
+```
+
+This keeps a bot-managed section in the PR description between:
+
+- `<!-- athrd-links:start -->`
+- `<!-- athrd-links:end -->`
+
+and recomputes links from all commit messages in the PR on each sync/open/edit event.
+
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE).


### PR DESCRIPTION
## Summary
- add a repo-owned GitHub Actions workflow to sync `athrd.com` links from PR commit messages into the PR body
- use `pull_request_target` with `pull-requests: write` so no external GitHub App install is required
- document the GitHub Actions approach in the root README
- remove `github-pr-app`-specific ignore entries from `.gitignore`

## Workflow behavior
- trigger events: `opened`, `reopened`, `synchronize`, `edited`, `ready_for_review`
- recompute links from all PR commits on each run
- maintain a bot-managed PR block between:
  - `<!-- athrd-links:start -->`
  - `<!-- athrd-links:end -->`
- dedupe links and trim trailing punctuation
- remove the section when no athrd links are present
