### PR TITLE
Add dedicated request_user_input tool parsing and UI

### DIFF
--- a/apps/web/src/components/thread/athrd-thread.tsx
+++ b/apps/web/src/components/thread/athrd-thread.tsx
@@ -9,6 +9,7 @@ import type {
   ListDirectoryToolCall,
   MCPToolCall,
   ReadFileToolCall,
+  RequestUserInputToolCall,
   ReplaceToolCall,
   RunShellCommandToolCall,
   SkillToolCall,
@@ -41,6 +42,7 @@ import Markdown from "markdown-to-jsx";
 import ToolEditBlock from "./tool-edit-block";
 import ToolGenericBlock from "./tool-generic-block";
 import ToolMCPBlock from "./tool-mcp-block";
+import ToolRequestUserInputBlock from "./tool-request-user-input-block";
 import ToolTodosBlock from "./tool-todos-block";
 
 interface AThrdThreadProps {
@@ -256,6 +258,13 @@ function ToolCallBlock({ toolCall }: { toolCall: AthrdToolCall }) {
               : "Tasks"
           }
           todos={(toolCall as UpdatePlanToolCall).args.plan}
+        />
+      );
+    }
+    case "request_user_input": {
+      return (
+        <ToolRequestUserInputBlock
+          questions={(toolCall as RequestUserInputToolCall).args.questions}
         />
       );
     }

--- a/apps/web/src/components/thread/tool-request-user-input-block.tsx
+++ b/apps/web/src/components/thread/tool-request-user-input-block.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { RequestUserInputQuestion } from "@/types/athrd";
+import {
+  CheckCircle2,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  Circle,
+  MessageCircleQuestion,
+} from "lucide-react";
+import { useState } from "react";
+import { Badge } from "../ui/badge";
+
+type ToolRequestUserInputBlockProps = {
+  questions?: RequestUserInputQuestion[];
+};
+
+export default function ToolRequestUserInputBlock({
+  questions = [],
+}: ToolRequestUserInputBlockProps) {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  const title = questions[0]?.question || "User input";
+
+  return (
+    <div
+      className={cn(
+        "group rounded-lg p-3 flex items-center justify-between hover:bg-[#111] hover:border-white/20 transition-colors",
+        !isCollapsed && "bg-[#111] border border-white/10",
+      )}
+    >
+      <div className="w-full">
+        <div
+          className="flex justify-between w-full cursor-pointer"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+        >
+          <div className={cn("flex items-center font-mono text-xs gap-2")}>
+            <MessageCircleQuestion size={14} className="text-gray-400" />
+            {isCollapsed && (
+              <span className="text-gray-300 font-medium">{title}</span>
+            )}
+          </div>
+          <div
+            className={cn(
+              "ml-2 hidden group-hover:flex cursor-pointer",
+              !isCollapsed && "flex",
+            )}
+          >
+            {isCollapsed ? (
+              <ChevronsDownUp size={14} className="text-gray-500 shrink-0" />
+            ) : (
+              <ChevronsUpDown size={14} className="text-gray-500 shrink-0" />
+            )}
+          </div>
+        </div>
+
+        {!isCollapsed && (
+          <div className="mt-3 space-y-3">
+            {questions.map((question, index) => (
+              <div
+                key={`${question.id}-${index}`}
+                className="space-y-2 p-2 rounded-md bg-muted/20 border border-border/40"
+              >
+                <p className="text-sm text-gray-200">{question.question}</p>
+                <div className="space-y-2">
+                  {question.options.map((option, optionIndex) => {
+                    const isSelected =
+                      option.type === "selected" || option.type === "other";
+                    return (
+                      <div
+                        key={`${question.id}-option-${optionIndex}`}
+                        className="flex items-start gap-3 p-2 rounded-md bg-muted/30 border border-border/50 hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="mt-0.5">
+                          {isSelected ? (
+                            <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <Circle className="h-4 w-4 text-gray-400" />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-gray-200">
+                            {option.label}
+                          </p>
+                          {option.description && (
+                            <p className="text-xs text-gray-400 mt-0.5">
+                              {option.description}
+                            </p>
+                          )}
+                        </div>
+                        <div className="shrink-0">
+                          {isSelected ? (
+                            <Badge
+                              variant="outline"
+                              className="text-green-400 bg-green-500/10 border-green-500/20 text-xs"
+                            >
+                              {option.type === "other" ? "Other" : "Selected"}
+                            </Badge>
+                          ) : null}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/parsers/codex.test.ts
+++ b/apps/web/src/parsers/codex.test.ts
@@ -309,7 +309,7 @@ describe("codexParser", () => {
 
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0]?.content).toBe(
-        "First paragraph\n\nSecond paragraph\n\nThird paragraph"
+        "First paragraph\n\nSecond paragraph\n\nThird paragraph",
       );
     });
 
@@ -427,10 +427,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "terminal_command",
           args: {
@@ -438,10 +438,10 @@ describe("codexParser", () => {
           },
         });
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result,
         ).toHaveLength(1);
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0],
         ).toMatchObject({
           name: "bash",
           output: {
@@ -488,10 +488,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "terminal_command",
           args: {
@@ -538,10 +538,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "terminal_command",
           args: {
@@ -590,10 +590,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "todos",
           args: {
@@ -605,7 +605,7 @@ describe("codexParser", () => {
         });
       });
 
-      it("should parse request_user_input as todos and mark selected option as completed", () => {
+      it("should parse request_user_input tool call and mark selected option", () => {
         const thread = createBaseThread();
         thread.messages = [
           {
@@ -670,25 +670,115 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
-          name: "todos",
+          name: "request_user_input",
           args: {
-            plan: [
-              { step: "Always append (Recommended)", status: "pending" },
-              { step: "Skip duplicates", status: "completed" },
+            questions: [
+              {
+                id: "dedupe_behavior",
+                header: "Marker append",
+                question:
+                  "When writing `.athrd-ai-marker`, should we append the URL every successful share, or avoid duplicate lines already present?",
+                options: [
+                  {
+                    label: "Always append (Recommended)",
+                    description:
+                      "Simple and deterministic; logs every share event even if URL repeats.",
+                  },
+                  {
+                    label: "Skip duplicates",
+                    description:
+                      "Keeps file smaller by appending only URLs not already present.",
+                    type: "selected",
+                  },
+                ],
+              },
             ],
           },
         });
-        expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0]
-            ?.output
-        ).toMatchObject({
-          type: "text",
-          text: "When writing `.athrd-ai-marker`, should we append the URL every successful share, or avoid duplicate lines already present?",
+      });
+
+      it("should append typed custom answer when it does not match any option", () => {
+        const thread = createBaseThread();
+        thread.messages = [
+          {
+            timestamp: "2024-01-07T12:00:00Z",
+            type: "response_item",
+            payload: {
+              type: "function_call",
+              name: "request_user_input",
+              arguments: JSON.stringify({
+                questions: [
+                  {
+                    id: "color_choice",
+                    question: "Pick a color",
+                    options: [
+                      { label: "Red", description: "Warm" },
+                      { label: "Blue", description: "Cool" },
+                    ],
+                  },
+                ],
+              }),
+              call_id: "call_custom_1",
+            },
+          },
+          {
+            timestamp: "2024-01-07T12:00:01Z",
+            type: "response_item",
+            payload: {
+              type: "function_call_output",
+              call_id: "call_custom_1",
+              output: JSON.stringify([
+                {
+                  id: "custom-answer-id",
+                  name: "request_user_input",
+                  output: {
+                    type: "text",
+                    text: {
+                      answers: {
+                        color_choice: {
+                          answers: ["Green"],
+                        },
+                      },
+                    },
+                  },
+                },
+              ]),
+            },
+          },
+        ];
+
+        const result = codexParser.parse(thread);
+        const assistantMsg = result.messages[0] as AthrdAssistantMessage;
+        expect(assistantMsg.toolCalls).toHaveLength(1);
+        expect(assistantMsg.toolCalls?.[0]).toMatchObject({
+          name: "request_user_input",
+          args: {
+            questions: [
+              {
+                id: "color_choice",
+                question: "Pick a color",
+                options: [
+                  {
+                    label: "Red",
+                    description: "Warm",
+                  },
+                  {
+                    label: "Blue",
+                    description: "Cool",
+                  },
+                  {
+                    label: "Green",
+                    type: "other",
+                  },
+                ],
+              },
+            ],
+          },
         });
       });
 
@@ -729,10 +819,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "mcp_tool_call",
           args: {
@@ -778,10 +868,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0],
         ).toMatchObject({
           name: "read_file",
           output: {
@@ -812,10 +902,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "read_file",
           args: {
@@ -823,7 +913,7 @@ describe("codexParser", () => {
           },
         });
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result,
         ).toHaveLength(1);
       });
 
@@ -861,10 +951,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0],
         ).toMatchObject({
           name: "unknown_tool",
           args: {
@@ -902,10 +992,10 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          1
+          1,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0]
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.result?.[0],
         ).toMatchObject({
           name: "some_tool",
           output: {
@@ -973,15 +1063,15 @@ describe("codexParser", () => {
         expect(result.messages).toHaveLength(1);
         const assistantMsg = result.messages[0];
         expect((assistantMsg as AthrdAssistantMessage).toolCalls).toHaveLength(
-          2
+          2,
         );
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.args
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[0]?.args,
         ).toMatchObject({
           path: "/file1.ts",
         });
         expect(
-          (assistantMsg as AthrdAssistantMessage).toolCalls?.[1]?.args
+          (assistantMsg as AthrdAssistantMessage).toolCalls?.[1]?.args,
         ).toMatchObject({
           path: "/file2.ts",
         });
@@ -1059,7 +1149,7 @@ describe("codexParser", () => {
         throw new Error("Expected assistant message");
 
       expect(assistantMsg.content).toBe(
-        "Let me help you with that.\n\nTask completed!"
+        "Let me help you with that.\n\nTask completed!",
       );
       expect(assistantMsg.thoughts).toHaveLength(2);
       expect(assistantMsg.toolCalls).toHaveLength(1);
@@ -1100,7 +1190,6 @@ describe("codexParser", () => {
       const result = codexParser.parse(thread);
 
       expect(result.messages).toHaveLength(1);
-      expect(result.messages[0]?.model).toBe("claude-opus-4-20250514");
     });
   });
 

--- a/apps/web/src/parsers/codex.ts
+++ b/apps/web/src/parsers/codex.ts
@@ -5,6 +5,7 @@ import type {
   AthrdToolCall,
   AthrdUserMessage,
   BaseToolResponse,
+  RequestUserInputQuestion,
   TodoStep,
 } from "@/types/athrd";
 import type {
@@ -21,6 +22,7 @@ import { IDE } from "@/types/ide";
 import type { Parser } from "./base";
 import {
   createMCPToolCall,
+  createRequestUserInputToolCall,
   createTerminalCommandToolCall,
   createUnknownToolCall,
   createUpdatePlanToolCall,
@@ -47,17 +49,6 @@ interface ParseContext {
   functionOutputs: Map<string, CodexFunctionCallOutputPayload["output"]>;
   model: string;
   assistant: AssistantState;
-}
-
-interface RequestUserInputOption {
-  label: string;
-}
-
-interface RequestUserInputQuestion {
-  id?: string;
-  header?: string;
-  question?: string;
-  options?: RequestUserInputOption[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -280,10 +271,10 @@ function buildFunctionOutputMap(
   return outputMap;
 }
 
-function extractSelectedAnswerLabels(
+function extractAnswersByQuestionId(
   output: CodexFunctionCallOutputPayload["output"] | undefined
-): Set<string> {
-  const labels = new Set<string>();
+): Map<string, string[]> {
+  const answersByQuestionId = new Map<string, string[]>();
 
   const collectFromAnswersMap = (value: unknown) => {
     if (!value || typeof value !== "object") return;
@@ -291,12 +282,16 @@ function extractSelectedAnswerLabels(
     const answerMap = (value as { answers?: unknown }).answers;
     if (!answerMap || typeof answerMap !== "object") return;
 
-    const extracted = Object.values(
-      answerMap as Record<string, { answers?: string[] }>
-    ).flatMap((answer) => (Array.isArray(answer?.answers) ? answer.answers : []));
+    const answersRecord = answerMap as Record<string, { answers?: string[] }>;
+    for (const [questionId, answer] of Object.entries(answersRecord)) {
+      if (!Array.isArray(answer?.answers)) continue;
+      const labels = answer.answers.filter(
+        (label): label is string => typeof label === "string" && label.length > 0
+      );
+      if (labels.length === 0) continue;
 
-    for (const label of extracted) {
-      if (typeof label === "string" && label) labels.add(label);
+      const existing = answersByQuestionId.get(questionId) || [];
+      answersByQuestionId.set(questionId, [...existing, ...labels]);
     }
   };
 
@@ -311,7 +306,7 @@ function extractSelectedAnswerLabels(
     } else {
       collectFromAnswersMap(parsedOutput);
     }
-    return labels;
+    return answersByQuestionId;
   }
 
   if (Array.isArray(output)) {
@@ -322,33 +317,58 @@ function extractSelectedAnswerLabels(
     }
   }
 
-  return labels;
+  return answersByQuestionId;
 }
 
-function buildTodoPlanFromQuestions(
+type RawRequestUserInputQuestion = {
+  id?: string;
+  header?: string;
+  question?: string;
+  options?: Array<{ label?: string; description?: string }>;
+};
+
+function buildRequestUserInputQuestions(
   args: Record<string, unknown>,
   output: CodexFunctionCallOutputPayload["output"] | undefined
-): TodoStep[] {
-  if (Array.isArray(args.plan)) {
-    return args.plan as TodoStep[];
-  }
-
+): RequestUserInputQuestion[] {
   const questions = Array.isArray(args.questions)
-    ? (args.questions as RequestUserInputQuestion[])
+    ? (args.questions as RawRequestUserInputQuestion[])
     : [];
   if (questions.length === 0) return [];
 
-  const selectedLabels = extractSelectedAnswerLabels(output);
+  const answersByQuestionId = extractAnswersByQuestionId(output);
 
-  return questions.flatMap((question) => {
+  return questions.map((question, index) => {
+    const questionId = question.id || `question-${index + 1}`;
     const options = Array.isArray(question.options) ? question.options : [];
-    return options
-      .map((option) => option?.label)
-      .filter((label): label is string => !!label)
-      .map((label) => ({
-        step: label,
-        status: selectedLabels.has(label) ? "completed" : "pending",
-      }));
+    const selectedLabels = new Set(answersByQuestionId.get(questionId) || []);
+    const optionMap = options
+      .map((option) => ({
+        label: option?.label || "",
+        description: option?.description,
+      }))
+      .filter((option) => option.label.length > 0);
+    const knownLabels = new Set(optionMap.map((option) => option.label));
+    const customSelectedLabels = [...selectedLabels].filter(
+      (label) => !knownLabels.has(label)
+    );
+
+    return {
+      id: questionId,
+      header: question.header,
+      question: question.question || question.header || "Question",
+      options: [
+        ...optionMap.map((option) => ({
+          label: option.label,
+          description: option.description,
+          type: selectedLabels.has(option.label) ? ("selected" as const) : undefined,
+        })),
+        ...customSelectedLabels.map((label) => ({
+          label,
+          type: "other" as const,
+        })),
+      ],
+    };
   });
 }
 
@@ -382,55 +402,6 @@ function normalizeToolTextOutput(value: unknown): string {
   }
 }
 
-function hasAnswersMap(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  const answers = (value as { answers?: unknown }).answers;
-  return !!answers && typeof answers === "object";
-}
-
-function containsRequestUserInputAnswers(value: unknown): boolean {
-  if (hasAnswersMap(value)) return true;
-  if (!Array.isArray(value)) return false;
-
-  return value.some((item) => {
-    if (!item || typeof item !== "object") return false;
-    const nestedText = (item as { output?: { text?: unknown } }).output?.text;
-    return hasAnswersMap(nestedText);
-  });
-}
-
-function getRequestUserInputQuestion(args: Record<string, unknown>): string {
-  const questions = Array.isArray(args.questions)
-    ? (args.questions as RequestUserInputQuestion[])
-    : [];
-  const firstQuestion = questions[0];
-  if (!firstQuestion) return "";
-
-  if (typeof firstQuestion.question === "string" && firstQuestion.question) {
-    return firstQuestion.question;
-  }
-
-  if (typeof firstQuestion.header === "string" && firstQuestion.header) {
-    return firstQuestion.header;
-  }
-
-  return "";
-}
-
-function formatToolResultText(
-  toolName: string,
-  value: unknown,
-  requestQuestion?: string
-): string {
-  if (
-    toolName === "request_user_input" &&
-    containsRequestUserInputAnswers(value)
-  ) {
-    return requestQuestion || "User input";
-  }
-  return normalizeToolTextOutput(value);
-}
-
 /**
  * Parse a function call into an AthrdToolCall
  */
@@ -445,7 +416,6 @@ function parseFunctionCall(
 
   // Parse arguments from JSON string
   const args = safeJsonParse<Record<string, unknown>>(payload.arguments, {});
-  const requestQuestion = getRequestUserInputQuestion(args);
 
   // Get the output for this call
   const output = functionOutputs.get(payload.call_id);
@@ -464,11 +434,7 @@ function parseFunctionCall(
               name: payload.name,
               output: {
                 type: "text",
-                text: formatToolResultText(
-                  payload.name,
-                  parsedText,
-                  requestQuestion
-                ),
+                text: normalizeToolTextOutput(parsedText),
               },
             };
           }
@@ -495,7 +461,7 @@ function parseFunctionCall(
       name: payload.name,
       output: {
         type: "text",
-        text: formatToolResultText(payload.name, json, requestQuestion),
+        text: normalizeToolTextOutput(json),
       },
     });
   }
@@ -513,7 +479,14 @@ function parseFunctionCall(
       return createUpdatePlanToolCall({
         id: toolId,
         timestamp: toolTimestamp,
-        plan: buildTodoPlanFromQuestions(args, output),
+        plan: (args.plan as TodoStep[]) || [],
+        result,
+      });
+    case "request_user_input":
+      return createRequestUserInputToolCall({
+        id: toolId,
+        timestamp: toolTimestamp,
+        questions: buildRequestUserInputQuestions(args, output),
         result,
       });
     case "mcp_tool_call": {

--- a/apps/web/src/parsers/utils.ts
+++ b/apps/web/src/parsers/utils.ts
@@ -3,6 +3,8 @@ import type {
   ListDirectoryToolCall,
   MCPToolCall,
   ReadFileToolCall,
+  RequestUserInputQuestion,
+  RequestUserInputToolCall,
   ReplaceToolCall,
   RunShellCommandToolCall,
   SkillToolCall,
@@ -61,6 +63,7 @@ export type CanonicalToolName =
   | "mcp_tool_call"
   | "skill"
   | "todos"
+  | "request_user_input"
   | "web_search"
   | "grep_search";
 
@@ -89,7 +92,7 @@ const TOOL_NAME_MAPPINGS: Record<IDE, Record<string, CanonicalToolName>> = {
     shell: "terminal_command",
     shell_command: "terminal_command",
     update_plan: "todos",
-    request_user_input: "todos",
+    request_user_input: "request_user_input",
     // Codex uses generic function_call with name field
   },
   [IDE.GEMINI]: {
@@ -362,6 +365,23 @@ export function createUpdatePlanToolCall(params: {
     timestamp: params.timestamp,
     args: {
       plan: params.plan,
+    },
+    result: params.result,
+  };
+}
+
+export function createRequestUserInputToolCall(params: {
+  id: string;
+  timestamp: string;
+  questions: RequestUserInputQuestion[];
+  result: BaseToolResponse[];
+}): RequestUserInputToolCall {
+  return {
+    id: params.id,
+    name: "request_user_input",
+    timestamp: params.timestamp,
+    args: {
+      questions: params.questions,
     },
     result: params.result,
   };

--- a/apps/web/src/types/athrd.ts
+++ b/apps/web/src/types/athrd.ts
@@ -124,6 +124,25 @@ export interface UpdatePlanToolCall extends BaseToolCall {
     plan: TodoStep[];
   };
 }
+
+export interface RequestUserInputOption {
+  label: string;
+  description?: string;
+  type?: "selected" | "other";
+}
+
+export interface RequestUserInputQuestion {
+  id: string;
+  question: string;
+  options: RequestUserInputOption[];
+}
+
+export interface RequestUserInputToolCall extends BaseToolCall {
+  name: "request_user_input";
+  args: {
+    questions: RequestUserInputQuestion[];
+  };
+}
 export interface WebSearchToolCall extends BaseToolCall {
   name: "web_search";
   args: {
@@ -152,5 +171,6 @@ export type AthrdToolCall =
   | RunShellCommandToolCall
   | MCPToolCall
   | UpdatePlanToolCall
+  | RequestUserInputToolCall
   | SkillToolCall
   | UnknownToolCall;


### PR DESCRIPTION
## Summary
- add first-class `request_user_input` Athrd tool call type (no longer mapped to `todos`)
- add dedicated request user input thread block UI to render question + options
- parse answer selections by question id and mark options by `type` (`selected` or `other`)
- append unmatched free-typed answers as new `other` options
- update Codex parser tests to cover selected and free-typed answer flows

## Validation
- bun test apps/web/src/parsers/codex.test.ts