### PR TITLE
Fix assistant message ordering in AssistantMessageGroup

### DIFF
--- a/apps/web/src/components/thread/athrd-thread.tsx
+++ b/apps/web/src/components/thread/athrd-thread.tsx
@@ -146,20 +146,7 @@ function AssistantMessageGroup({
 }: {
   messages: AthrdAssistantMessage[];
 }) {
-  const [showLeadingDetails, setShowLeadingDetails] = useState(false);
-
-  type CollapsibleItem =
-    | {
-        kind: "thought";
-        key: string;
-        subject: string;
-        description: string;
-      }
-    | {
-        kind: "tool";
-        key: string;
-        toolCall: AthrdToolCall;
-      };
+  const [showPreviousDetails, setShowPreviousDetails] = useState(false);
 
   type AssistantRenderBlock =
     | {
@@ -180,53 +167,26 @@ function AssistantMessageGroup({
       };
 
   const renderBlocks: AssistantRenderBlock[] = [];
-  const leadingItems: CollapsibleItem[] = [];
-  let leadingThoughtCount = 0;
-  let leadingToolCallCount = 0;
-  let seenContent = false;
-  const leadingSummaryParts: string[] = [];
 
   messages.forEach((message, messageIndex) => {
     message.thoughts?.forEach((thought, thoughtIndex) => {
-      const key = `thought-${message.id}-${thoughtIndex}`;
-      if (!seenContent) {
-        leadingItems.push({
-          kind: "thought",
-          key,
-          subject: thought.subject,
-          description: thought.description,
-        });
-        leadingThoughtCount += 1;
-      } else {
-        renderBlocks.push({
-          type: "thought",
-          key,
-          subject: thought.subject,
-          description: thought.description,
-        });
-      }
+      renderBlocks.push({
+        type: "thought",
+        key: `thought-${message.id}-${thoughtIndex}`,
+        subject: thought.subject,
+        description: thought.description,
+      });
     });
 
     message.toolCalls?.forEach((toolCall, toolIndex) => {
-      const key = `tool-${message.id}-${toolCall.id}-${toolIndex}`;
-      if (!seenContent) {
-        leadingItems.push({
-          kind: "tool",
-          key,
-          toolCall,
-        });
-        leadingToolCallCount += 1;
-      } else {
-        renderBlocks.push({
-          type: "tool",
-          key,
-          toolCall,
-        });
-      }
+      renderBlocks.push({
+        type: "tool",
+        key: `tool-${message.id}-${toolCall.id}-${toolIndex}`,
+        toolCall,
+      });
     });
 
     if (message.content) {
-      seenContent = true;
       renderBlocks.push({
         type: "content",
         key: `assistant-content-${message.id}-${messageIndex}`,
@@ -235,11 +195,25 @@ function AssistantMessageGroup({
     }
   });
 
-  if (leadingThoughtCount > 0) {
-    leadingSummaryParts.push(`Thinking (x${leadingThoughtCount})`);
+  const lastBlockIndex = renderBlocks.length - 1;
+  const hiddenBlocks = renderBlocks.slice(0, lastBlockIndex);
+  const hiddenThoughtCount = hiddenBlocks.filter(
+    (block) => block.type === "thought"
+  ).length;
+  const hiddenToolCallCount = hiddenBlocks.filter(
+    (block) => block.type === "tool"
+  ).length;
+  const hiddenCount = hiddenBlocks.length;
+  const hiddenSummaryParts: string[] = [];
+
+  if (hiddenThoughtCount > 0) {
+    hiddenSummaryParts.push(`Thinking (x${hiddenThoughtCount})`);
   }
-  if (leadingToolCallCount > 0) {
-    leadingSummaryParts.push(`Tool calls (x${leadingToolCallCount})`);
+  if (hiddenToolCallCount > 0) {
+    hiddenSummaryParts.push(`Tool calls (x${hiddenToolCallCount})`);
+  }
+  if (hiddenSummaryParts.length === 0 && hiddenCount > 0) {
+    hiddenSummaryParts.push(`Previous messages (x${hiddenCount})`);
   }
 
   return (
@@ -250,66 +224,43 @@ function AssistantMessageGroup({
         </AvatarFallback>
       </Avatar>
       <div className="space-y-2 min-w-0 max-w-full flex-1">
-        {leadingItems.length > 0 && (
+        {hiddenCount > 0 && (
           <div className="py-1">
             <button
               type="button"
-              onClick={() => setShowLeadingDetails((prev) => !prev)}
+              onClick={() => setShowPreviousDetails((prev) => !prev)}
               className="group flex w-full items-center gap-3 text-xs text-gray-400 hover:text-gray-200 transition-colors"
-              aria-expanded={showLeadingDetails}
+              aria-expanded={showPreviousDetails}
               aria-label={
-                showLeadingDetails
-                  ? "Collapse thinking and tool calls"
-                  : "Expand thinking and tool calls"
+                showPreviousDetails
+                  ? "Collapse previous assistant messages"
+                  : "Expand previous assistant messages"
               }
             >
-              {showLeadingDetails ? (
+              {showPreviousDetails ? (
                 <ChevronDownIcon className="h-3.5 w-3.5 shrink-0" />
               ) : (
                 <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
               )}
               <span className="h-px flex-1 bg-white/20 transition-colors group-hover:bg-white/40" />
-              <span>{leadingSummaryParts.join(" · ")}</span>
+              <span>{hiddenSummaryParts.join(" · ")}</span>
               <span className="h-px flex-1 bg-white/20 transition-colors group-hover:bg-white/40" />
             </button>
-
-            <div className={cn("space-y-2 mt-2", !showLeadingDetails && "hidden")}>
-              {leadingItems.map((item) => {
-                if (item.kind === "thought") {
-                  return (
-                    <ToolGenericBlock
-                      key={item.key}
-                      results={[
-                        {
-                          id: item.key,
-                          name: "Thought",
-                          output: {
-                            type: "text",
-                            text: item.description,
-                          },
-                        },
-                      ]}
-                      title={item.subject}
-                      icon={BrainCogIcon}
-                    />
-                  );
-                }
-                return <ToolCallBlock key={item.key} toolCall={item.toolCall} />;
-              })}
-
-              <div className="flex items-center gap-4 text-xs text-gray-500 select-none pt-1">
-                <span className="h-px flex-1 bg-white/15" />
-                <span>End</span>
-                <span className="h-px flex-1 bg-white/15" />
-              </div>
-            </div>
           </div>
         )}
 
-        {renderBlocks.map((block) => {
+        {renderBlocks.map((block, blockIndex) => {
+          const shouldHide = !showPreviousDetails && blockIndex < lastBlockIndex;
+
           if (block.type === "content") {
             return (
-              <div key={block.key} className="markdown-content text-sm text-gray-300 py-2">
+              <div
+                key={block.key}
+                className={cn(
+                  "markdown-content text-sm text-gray-300 py-2",
+                  shouldHide && "hidden"
+                )}
+              >
                 <Markdown>{block.content}</Markdown>
               </div>
             );
@@ -317,25 +268,30 @@ function AssistantMessageGroup({
 
           if (block.type === "thought") {
             return (
-              <ToolGenericBlock
-                key={block.key}
-                results={[
-                  {
-                    id: block.key,
-                    name: "Thought",
-                    output: {
-                      type: "text",
-                      text: block.description,
+              <div key={block.key} className={cn(shouldHide && "hidden")}>
+                <ToolGenericBlock
+                  results={[
+                    {
+                      id: block.key,
+                      name: "Thought",
+                      output: {
+                        type: "text",
+                        text: block.description,
+                      },
                     },
-                  },
-                ]}
-                title={block.subject}
-                icon={BrainCogIcon}
-              />
+                  ]}
+                  title={block.subject}
+                  icon={BrainCogIcon}
+                />
+              </div>
             );
           }
 
-          return <ToolCallBlock key={block.key} toolCall={block.toolCall} />;
+          return (
+            <div key={block.key} className={cn(shouldHide && "hidden")}>
+              <ToolCallBlock toolCall={block.toolCall} />
+            </div>
+          );
         })}
       </div>
     </div>

--- a/apps/web/src/parsers/codex.test.ts
+++ b/apps/web/src/parsers/codex.test.ts
@@ -257,20 +257,30 @@ describe("codexParser", () => {
 
       const result = codexParser.parse(thread);
 
-      expect(result.messages).toHaveLength(1);
-      const assistantMsg = result.messages[0];
-      expect(assistantMsg?.type).toBe("assistant");
-      if (assistantMsg?.type !== "assistant")
-        throw new Error("Expected assistant message");
-      expect(assistantMsg.thoughts).toHaveLength(2);
-      expect(assistantMsg.thoughts?.[0]).toMatchObject({
+      expect(result.messages).toHaveLength(2);
+
+      const reasoningMsg = result.messages[0];
+      expect(reasoningMsg?.type).toBe("assistant");
+      if (reasoningMsg?.type !== "assistant")
+        throw new Error("Expected assistant reasoning message");
+      expect(reasoningMsg.content).toBe("");
+      expect(reasoningMsg.thoughts).toHaveLength(2);
+      expect(reasoningMsg.thoughts?.[0]).toMatchObject({
         subject: "Analysis",
         description: "Let me analyze this problem...",
       });
-      expect(assistantMsg.thoughts?.[1]).toMatchObject({
+      expect(reasoningMsg.thoughts?.[1]).toMatchObject({
         subject: "Thinking",
         description: "Detailed thinking process here",
       });
+
+      const responseMsg = result.messages[1];
+      expect(responseMsg?.type).toBe("assistant");
+      if (responseMsg?.type !== "assistant")
+        throw new Error("Expected assistant text message");
+      expect(responseMsg.content).toBe("Here's my response");
+      expect(responseMsg.thoughts).toBeUndefined();
+      expect(responseMsg.toolCalls).toBeUndefined();
     });
 
     it("should handle multiple text blocks in assistant message", () => {
@@ -381,15 +391,24 @@ describe("codexParser", () => {
 
       const result = codexParser.parse(thread);
 
-      expect(result.messages).toHaveLength(1);
-      const assistantMsg = result.messages[0];
-      if (assistantMsg?.type !== "assistant")
-        throw new Error("Expected assistant message");
-      expect(assistantMsg.thoughts).toHaveLength(1);
-      expect(assistantMsg.thoughts?.[0]).toMatchObject({
+      expect(result.messages).toHaveLength(2);
+
+      const reasoningMsg = result.messages[0];
+      if (reasoningMsg?.type !== "assistant")
+        throw new Error("Expected assistant reasoning message");
+      expect(reasoningMsg.content).toBe("");
+      expect(reasoningMsg.thoughts).toHaveLength(1);
+      expect(reasoningMsg.thoughts?.[0]).toMatchObject({
         subject: "Planning",
         description: "Creating a plan...",
       });
+
+      const responseMsg = result.messages[1];
+      if (responseMsg?.type !== "assistant")
+        throw new Error("Expected assistant text message");
+      expect(responseMsg.content).toBe("Plan created");
+      expect(responseMsg.thoughts).toBeUndefined();
+      expect(responseMsg.toolCalls).toBeUndefined();
     });
 
     describe("tool calls", () => {
@@ -1143,16 +1162,28 @@ describe("codexParser", () => {
 
       const result = codexParser.parse(thread);
 
-      expect(result.messages).toHaveLength(1);
-      const assistantMsg = result.messages[0];
-      if (assistantMsg?.type !== "assistant")
-        throw new Error("Expected assistant message");
+      expect(result.messages).toHaveLength(3);
 
-      expect(assistantMsg.content).toBe(
-        "Let me help you with that.\n\nTask completed!",
-      );
-      expect(assistantMsg.thoughts).toHaveLength(2);
-      expect(assistantMsg.toolCalls).toHaveLength(1);
+      const firstMsg = result.messages[0];
+      if (firstMsg?.type !== "assistant")
+        throw new Error("Expected first assistant message");
+      expect(firstMsg.content).toBe("Let me help you with that.");
+      expect(firstMsg.thoughts).toBeUndefined();
+      expect(firstMsg.toolCalls).toBeUndefined();
+
+      const secondMsg = result.messages[1];
+      if (secondMsg?.type !== "assistant")
+        throw new Error("Expected second assistant message");
+      expect(secondMsg.content).toBe("");
+      expect(secondMsg.thoughts).toHaveLength(2);
+      expect(secondMsg.toolCalls).toHaveLength(1);
+
+      const thirdMsg = result.messages[2];
+      if (thirdMsg?.type !== "assistant")
+        throw new Error("Expected third assistant message");
+      expect(thirdMsg.content).toBe("Task completed!");
+      expect(thirdMsg.thoughts).toBeUndefined();
+      expect(thirdMsg.toolCalls).toBeUndefined();
     });
   });
 

--- a/apps/web/src/parsers/codex.ts
+++ b/apps/web/src/parsers/codex.ts
@@ -67,6 +67,10 @@ function hasAssistantContent(state: AssistantState): boolean {
   );
 }
 
+function hasAssistantText(state: AssistantState): boolean {
+  return state.content.length > 0;
+}
+
 function flushAssistant(ctx: ParseContext): void {
   if (!hasAssistantContent(ctx.assistant)) return;
 
@@ -127,6 +131,12 @@ function handleResponseMessage(
     const textContent = extractTextContent(payload.content, "output_text");
     if (!textContent.trim()) return;
 
+    // Preserve event ordering by separating text blocks from reasoning/tool blocks.
+    // When text arrives after non-text assistant events, flush first.
+    if (hasAssistantContent(ctx.assistant) && !hasAssistantText(ctx.assistant)) {
+      flushAssistant(ctx);
+    }
+
     ctx.assistant.content.push(textContent);
     ctx.assistant.timestamp = normalizeTimestamp(timestamp);
     ensureAssistantId(ctx.assistant);
@@ -138,6 +148,11 @@ function handleFunctionCall(
   payload: CodexFunctionCallPayload,
   timestamp: string
 ): void {
+  // Preserve event ordering by separating text blocks from reasoning/tool blocks.
+  if (hasAssistantText(ctx.assistant)) {
+    flushAssistant(ctx);
+  }
+
   const toolCall = parseFunctionCall(payload, timestamp, ctx.functionOutputs);
   ctx.assistant.toolCalls.push(toolCall);
   ctx.assistant.timestamp = normalizeTimestamp(timestamp);
@@ -149,6 +164,11 @@ function handleReasoning(
   payload: CodexReasoningPayload,
   timestamp: string
 ): void {
+  // Preserve event ordering by separating text blocks from reasoning/tool blocks.
+  if (hasAssistantText(ctx.assistant)) {
+    flushAssistant(ctx);
+  }
+
   const normalizedTimestamp = normalizeTimestamp(timestamp);
 
   for (const summary of payload.summary ?? []) {


### PR DESCRIPTION
## Summary
- remove the leading grouping/merge path in AssistantMessageGroup and render a flat ordered list of assistant blocks
- keep counter logic for previous thinking and tool calls
- hide all previous blocks by default with a CSS class, and toggle visibility while always keeping the last block visible
- preserve parser-side ordering boundaries between assistant text and non-text events

## Validation
- bun x tsc --noEmit -p apps/web/tsconfig.json
- bun test apps/web/src/parsers/codex.test.ts

---
# Agent Session(s)
Agent-Session: https://athrd.com/threads/6ae4253e760ead9fe0b3aedd2cbd3ed9
Agent-Session: https://athrd.com/threads/fc97bf418dd238b44239ca5e25e69a40