### PR TITLE
Prevent duplicate thread entries in .agent-session-marker

### DIFF
--- a/packages/cli/src/utils/commit-backfill.test.ts
+++ b/packages/cli/src/utils/commit-backfill.test.ts
@@ -8,7 +8,10 @@ import {
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { backfillRecentHeadAgentSessionTrailer } from "./commit-backfill.js";
+import {
+  backfillRecentHeadAgentSessionTrailer,
+  headHasAgentSessionTrailer,
+} from "./commit-backfill.js";
 
 const tempDirs: string[] = [];
 
@@ -126,6 +129,29 @@ describe("backfillRecentHeadAgentSessionTrailer", () => {
 
     const result = backfillRecentHeadAgentSessionTrailer({ cwd: repo, url });
     expect(result.status).toBe("skipped:trailer_exists");
+  });
+
+  test("detects matching trailer on HEAD", () => {
+    const repo = makeTempDir("athrd-backfill-detect-trailer-");
+    initRepoWithIdentity(repo);
+    commitFile(repo, "feat: base");
+
+    const url = "https://athrd.com/threads/detect";
+    execSync(
+      `git commit --amend --no-edit --no-verify --trailer "Agent-Session: ${url}"`,
+      {
+        cwd: repo,
+        stdio: "ignore",
+      },
+    );
+
+    expect(headHasAgentSessionTrailer({ cwd: repo, url })).toBeTrue();
+    expect(
+      headHasAgentSessionTrailer({
+        cwd: repo,
+        url: "https://athrd.com/threads/other",
+      }),
+    ).toBeFalse();
   });
 
   test("skips outside a git repository", () => {

--- a/packages/cli/src/utils/commit-backfill.ts
+++ b/packages/cli/src/utils/commit-backfill.ts
@@ -25,6 +25,11 @@ interface BackfillRecentHeadAgentSessionTrailerParams {
   url: string;
 }
 
+interface HeadHasAgentSessionTrailerParams {
+  cwd?: string;
+  url: string;
+}
+
 function runGit(args: string[], cwd: string): string {
   return execFileSync("git", args, {
     cwd,
@@ -85,6 +90,29 @@ function hasMatchingTrailer(message: string, url: string): boolean {
     }
   }
   return false;
+}
+
+export function headHasAgentSessionTrailer(
+  params: HeadHasAgentSessionTrailerParams,
+): boolean {
+  const url = params.url.trim();
+  if (!url) {
+    return false;
+  }
+
+  const repoRoot = getGitRepoRoot(params.cwd);
+  if (!repoRoot || !hasHead(repoRoot)) {
+    return false;
+  }
+
+  let message = "";
+  try {
+    message = runGit(["log", "-1", "--pretty=%B", "HEAD"], repoRoot);
+  } catch {
+    return false;
+  }
+
+  return hasMatchingTrailer(message, url);
 }
 
 export function backfillRecentHeadAgentSessionTrailer(

--- a/packages/cli/src/utils/marker.test.ts
+++ b/packages/cli/src/utils/marker.test.ts
@@ -96,6 +96,29 @@ describe("appendAthrdUrlMarker", () => {
 
     expect(existsSync(join(dir, ".agent-session-marker"))).toBeFalse();
   });
+
+  test("does not append when HEAD already has matching agent-session trailer", () => {
+    const root = makeTempDir("athrd-marker-head-associated-");
+    execSync("git init", { cwd: root, stdio: "ignore" });
+    execSync('git config user.email "athrd-tests@example.com"', {
+      cwd: root,
+      stdio: "ignore",
+    });
+    execSync('git config user.name "athrd-tests"', { cwd: root, stdio: "ignore" });
+    writeFileSync(join(root, "file.txt"), "base\n", "utf-8");
+    execSync("git add file.txt", { cwd: root, stdio: "ignore" });
+    execSync('git commit -m "feat: base"', { cwd: root, stdio: "ignore" });
+
+    const url = "https://athrd.com/threads/abc";
+    execSync(
+      `git commit --amend --no-edit --no-verify --trailer "Agent-Session: ${url}"`,
+      { cwd: root, stdio: "ignore" },
+    );
+
+    appendAthrdUrlMarker({ cwd: root, url });
+
+    expect(existsSync(join(root, ".agent-session-marker"))).toBeFalse();
+  });
 });
 
 describe("removeAthrdUrlMarker", () => {

--- a/packages/cli/src/utils/marker.ts
+++ b/packages/cli/src/utils/marker.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { headHasAgentSessionTrailer } from "./commit-backfill.js";
 import { getGitRepoRoot } from "./git.js";
 
 interface AppendAthrdUrlMarkerParams {
@@ -40,14 +41,18 @@ export function appendAthrdUrlMarker(params: AppendAthrdUrlMarkerParams): void {
     return;
   }
 
-  ensureMarkerIgnored(gitRoot);
-
-  const markerPath = path.join(gitRoot, ".agent-session-marker");
   const normalizedUrl = params.url.trim();
   if (!normalizedUrl) {
     return;
   }
 
+  if (headHasAgentSessionTrailer({ cwd: gitRoot, url: normalizedUrl })) {
+    return;
+  }
+
+  ensureMarkerIgnored(gitRoot);
+
+  const markerPath = path.join(gitRoot, ".agent-session-marker");
   let existingContent = "";
   if (fs.existsSync(markerPath)) {
     existingContent = fs.readFileSync(markerPath, "utf-8");


### PR DESCRIPTION
## Summary
- add a HEAD trailer check helper () in commit backfill utils
- skip  append when HEAD already has matching  trailer for the same thread URL
- add regression tests for trailer detection and marker append skip behavior

## Testing
- bun test packages/cli/src/utils/marker.test.ts packages/cli/src/utils/commit-backfill.test.ts packages/cli/src/utils/hook-share-backfill.test.ts

Closes #29

---
# Agent Session(s)
- https://athrd.com/threads/6b36b9ac26d2c08194769119b5566dc0
- https://athrd.com/threads/2a000828c3d3ef93f9601c7bcb053b34