### PR TITLE
fix(cli): repair stale athrd hooksPath

### DIFF
--- a/packages/cli/src/utils/git-hooks.test.ts
+++ b/packages/cli/src/utils/git-hooks.test.ts
@@ -91,6 +91,61 @@ describe("global git hook install/uninstall", () => {
     );
   });
 
+  test("install repairs stale athrd-managed global hooksPath", () => {
+    const staleHooksPath = makeTempDir("athrd-global-hooks-stale-");
+    runGit(["config", "--global", "core.hooksPath", staleHooksPath]);
+    rmSync(staleHooksPath, { recursive: true, force: true });
+
+    const statePath = join(process.env.ATHRD_HOME!, "git-hooks", "state.json");
+    mkdirSync(join(process.env.ATHRD_HOME!, "git-hooks"), { recursive: true });
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        managedByAthrd: true,
+        previousHooksPath: null,
+      }),
+      "utf-8",
+    );
+
+    installGlobalCommitMsgHook();
+
+    const repairedHooksPath = runGit([
+      "config",
+      "--global",
+      "--get",
+      "core.hooksPath",
+    ]);
+    const repairedHook = join(repairedHooksPath, "commit-msg");
+
+    expect(repairedHooksPath).toBe(join(process.env.ATHRD_HOME!, "git-hooks"));
+    expect(existsSync(repairedHook)).toBeTrue();
+    expect(readFileSync(repairedHook, "utf-8")).toContain(
+      "# ATHRD_MANAGED_COMMIT_MSG",
+    );
+  });
+
+  test("install resets athrd-managed hooksPath drift even when stale dir still exists", () => {
+    const driftedHooksPath = makeTempDir("athrd-global-hooks-drifted-");
+    runGit(["config", "--global", "core.hooksPath", driftedHooksPath]);
+
+    const statePath = join(process.env.ATHRD_HOME!, "git-hooks", "state.json");
+    mkdirSync(join(process.env.ATHRD_HOME!, "git-hooks"), { recursive: true });
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        managedByAthrd: true,
+        previousHooksPath: null,
+      }),
+      "utf-8",
+    );
+
+    installGlobalCommitMsgHook();
+
+    expect(runGit(["config", "--global", "--get", "core.hooksPath"])).toBe(
+      join(process.env.ATHRD_HOME!, "git-hooks"),
+    );
+  });
+
   test("uninstall restores previous commit-msg hook in existing hooksPath", () => {
     const hooksDir = makeTempDir("athrd-existing-hooks-");
     const existingHook = join(hooksDir, "commit-msg");

--- a/packages/cli/src/utils/git-hooks.ts
+++ b/packages/cli/src/utils/git-hooks.ts
@@ -34,6 +34,14 @@ function getCommitMsgHookPathForDir(hooksDir: string): string {
   return path.join(hooksDir, "commit-msg");
 }
 
+function pathsEqual(left: string | null, right: string | null): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+
+  return path.resolve(left) === path.resolve(right);
+}
+
 function getCurrentGlobalHooksPath(): string | null {
   try {
     const value = execFileSync(
@@ -326,8 +334,8 @@ export function installGlobalCommitMsgHook(): void {
 
   if (state?.managedByAthrd) {
     writeCommitMsgHook(state.targetHooksPath, state.backupHookPath);
-    if (state.updatedGlobalHooksPath && currentHooksPath !== globalHooksDir) {
-      setGlobalHooksPath(globalHooksDir);
+    if (!pathsEqual(currentHooksPath, state.targetHooksPath)) {
+      setGlobalHooksPath(state.targetHooksPath);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- repair athrd-managed hook installs when global core.hooksPath drifts to a stale or temporary directory
- keep the saved athrd target hooks path authoritative during reinstall
- add regression tests for both missing and still-existing stale hook path scenarios

## Testing
- bun test ./packages/cli/src/utils/git-hooks.test.ts
- bun run build (in packages/cli)

---
# Agent Session(s)
- https://athrd.com/threads/b54091d9f7324af0feb8f270b02adc4f