### PR TITLE
Request read-only GitHub org access

### DIFF
--- a/apps/web/src/server/better-auth/config.ts
+++ b/apps/web/src/server/better-auth/config.ts
@@ -35,7 +35,7 @@ export const auth = betterAuth({
     github: {
       clientId: env.BETTER_AUTH_GITHUB_CLIENT_ID,
       clientSecret: env.BETTER_AUTH_GITHUB_CLIENT_SECRET,
-      scope: ["gist"],
+      scope: ["gist", "read:org"],
     },
   },
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -30,7 +30,7 @@ export function authCommand(program: Command) {
         const auth = createOAuthDeviceAuth({
           clientType: "oauth-app",
           clientId: config.github.clientId,
-          scopes: ["gist", "read:user", "user:email"],
+          scopes: ["gist", "read:user", "user:email", "read:org"],
           onVerification: async (verification) => {
             console.log(chalk.bold("Please authorize this app by visiting:"));
             console.log(chalk.blue.underline(verification.verification_uri));


### PR DESCRIPTION
## Summary
- add the GitHub  OAuth scope to web sign-in
- add the same  scope to the CLI device auth flow
- keep access read-only while enabling organization membership checks

---
# Agent Session(s)
- https://athrd.com/threads/0b7dd84084e624e6ea12e73562f290b5
- https://athrd.com/threads/e0da9a858aeb2699a6bc41a872d94675