### PR TITLE
Collapse Codex agent instructions in thread view

### DIFF
--- a/apps/web/src/components/thread/athrd-thread.tsx
+++ b/apps/web/src/components/thread/athrd-thread.tsx
@@ -30,6 +30,7 @@ import {
   maybeShortenFilePathLinkChildren,
   mergeRel,
 } from "@/components/thread/markdown-render-utils";
+import { shouldCollapseUserMessageGroup } from "@/components/thread/user-message-group-utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -53,12 +54,8 @@ import {
 } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import { useEffect, useState } from "react";
+import { getThreadAnchorId, groupMessages } from "./thread-anchor-utils";
 import ToolEditBlock from "./tool-edit-block";
-import {
-  getThreadAnchorHref,
-  getThreadAnchorId,
-  groupMessages,
-} from "./thread-anchor-utils";
 import ToolGenericBlock from "./tool-generic-block";
 import ToolMCPBlock from "./tool-mcp-block";
 import ToolRequestUserInputBlock from "./tool-request-user-input-block";
@@ -183,14 +180,15 @@ export default function AThrdThread({
     <div className="athrd-thread space-y-6 lg:px-32 lg:py-8 px-2 md:px-16">
       {messageGroups.map((group, groupIdx) => {
         if (group.type === "user") {
-          return group.messages.map((message, index) => (
-            <UserMessage
-              key={`${message.id}-${groupIdx}-${index}`}
+          return (
+            <UserMessageGroup
+              key={`user-group-${groupIdx}`}
+              anchorId={group.anchorId}
               owner={owner}
-              message={message as AthrdUserMessage}
+              messages={group.messages as AthrdUserMessage[]}
               markdownOptions={markdownOptions}
             />
-          ));
+          );
         }
         return (
           <AssistantMessageGroup
@@ -206,28 +204,36 @@ export default function AThrdThread({
 }
 
 /**
- * Render a user message
+ * Render a group of consecutive user messages with a single avatar.
  */
-function UserMessage({
+function UserMessageGroup({
+  anchorId,
   owner,
-  message,
+  messages,
   markdownOptions,
 }: {
+  anchorId: string;
   owner?: ThreadSourceOwner;
-  message: AthrdUserMessage;
+  messages: AthrdUserMessage[];
   markdownOptions: MarkdownOptions;
 }) {
   const ownerLabel = owner?.login || "You";
+  const [showPreviousDetails, setShowPreviousDetails] = useState(false);
+  const shouldCollapsePreviousMessages =
+    shouldCollapseUserMessageGroup(messages);
+  const hiddenMessages = shouldCollapsePreviousMessages
+    ? messages.slice(0, -1)
+    : [];
+  const visibleMessages = shouldCollapsePreviousMessages
+    ? messages.slice(-1)
+    : messages;
 
   return (
     <div
-      id={getThreadAnchorId(message.id)}
+      id={anchorId}
       className="group/thread-item flex scroll-mt-24 flex-col items-start gap-2 sm:flex-row sm:gap-4"
     >
-      <ThreadAnchor
-        href={getThreadAnchorHref(message.id)}
-        label="Link to this prompt"
-      >
+      <ThreadAnchor href={`#${anchorId}`} label="Link to this prompt">
         <Avatar className="h-8 w-8 border border-white/10">
           <AvatarImage src={owner?.avatarUrl} alt={ownerLabel} />
           <AvatarFallback className="bg-blue-900/30 text-blue-200 text-xs">
@@ -235,11 +241,56 @@ function UserMessage({
           </AvatarFallback>
         </Avatar>
       </ThreadAnchor>
-      <Card className="w-full max-w-[min(74ch,100%)] min-w-0 gap-2 border-white/10 bg-[#111] p-4 text-gray-300 shadow-none">
-        <div className="markdown-content">
-          <Markdown options={markdownOptions}>{message.content}</Markdown>
-        </div>
-      </Card>
+      <div className="space-y-2 min-w-0 max-w-full flex-1">
+        {hiddenMessages.length > 0 && (
+          <div className="py-1">
+            <button
+              type="button"
+              onClick={() => setShowPreviousDetails((prev) => !prev)}
+              className="group flex w-full items-center gap-3 text-xs text-gray-400 hover:text-gray-200 transition-colors"
+              aria-expanded={showPreviousDetails}
+              aria-label={
+                showPreviousDetails
+                  ? "Collapse agent instructions"
+                  : "Expand agent instructions"
+              }
+            >
+              {showPreviousDetails ? (
+                <ChevronDownIcon className="h-3.5 w-3.5 shrink-0" />
+              ) : (
+                <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
+              )}
+              <span className="h-px flex-1 bg-white/20 transition-colors group-hover:bg-white/40" />
+              <span>Agent instructions</span>
+              <span className="h-px flex-1 bg-white/20 transition-colors group-hover:bg-white/40" />
+            </button>
+            {hiddenMessages.map((message) => (
+              <div
+                key={message.id}
+                id={getThreadAnchorId(message.id)}
+                className={cn(
+                  "markdown-content max-w-[74ch] py-2 text-white/92",
+                  !showPreviousDetails && "hidden",
+                )}
+              >
+                <Markdown options={markdownOptions}>{message.content}</Markdown>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {visibleMessages.map((message) => (
+          <Card
+            key={message.id}
+            id={getThreadAnchorId(message.id)}
+            className="w-full max-w-[min(74ch,100%)] min-w-0 gap-2 border-white/10 bg-[#111] p-4 text-gray-300 shadow-none"
+          >
+            <div className="markdown-content">
+              <Markdown options={markdownOptions}>{message.content}</Markdown>
+            </div>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/thread/user-message-group-utils.test.ts
+++ b/apps/web/src/components/thread/user-message-group-utils.test.ts
@@ -1,0 +1,39 @@
+import type { AthrdUserMessage } from "@/types/athrd";
+import { describe, expect, it } from "vitest";
+import { shouldCollapseUserMessageGroup } from "./user-message-group-utils";
+
+function createUserMessage(
+  id: string,
+  variant?: AthrdUserMessage["variant"],
+): AthrdUserMessage {
+  return {
+    id,
+    type: "user",
+    content: `message ${id}`,
+    variant,
+  };
+}
+
+describe("user-message-group-utils", () => {
+  it("collapses leading agent instructions into the same group as the final prompt", () => {
+    expect(
+      shouldCollapseUserMessageGroup([
+        createUserMessage("u1", "agent-instructions"),
+        createUserMessage("u2"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not collapse single user messages", () => {
+    expect(shouldCollapseUserMessageGroup([createUserMessage("u1")])).toBe(false);
+  });
+
+  it("does not collapse when earlier messages are real prompts", () => {
+    expect(
+      shouldCollapseUserMessageGroup([
+        createUserMessage("u1"),
+        createUserMessage("u2"),
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/thread/user-message-group-utils.ts
+++ b/apps/web/src/components/thread/user-message-group-utils.ts
@@ -1,0 +1,11 @@
+import { isAgentInstructionsUserMessage } from "@/lib/codex-message-utils";
+import type { AthrdUserMessage } from "@/types/athrd";
+
+export function shouldCollapseUserMessageGroup(
+  messages: AthrdUserMessage[],
+): boolean {
+  return (
+    messages.length > 1 &&
+    messages.slice(0, -1).every((message) => isAgentInstructionsUserMessage(message))
+  );
+}

--- a/apps/web/src/lib/codex-message-utils.test.ts
+++ b/apps/web/src/lib/codex-message-utils.test.ts
@@ -1,0 +1,35 @@
+import type { AthrdUserMessage } from "@/types/athrd";
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_INSTRUCTIONS_PREFIX,
+  isAgentInstructionsMessageContent,
+  isAgentInstructionsUserMessage,
+} from "./codex-message-utils";
+
+describe("codex-message-utils", () => {
+  it("detects the Codex AGENTS.md bootstrap prefix", () => {
+    expect(
+      isAgentInstructionsMessageContent(
+        `${AGENT_INSTRUCTIONS_PREFIX}/Users/example/project\n\n<INSTRUCTIONS>...`,
+      ),
+    ).toBe(true);
+    expect(isAgentInstructionsMessageContent("Real user prompt")).toBe(false);
+  });
+
+  it("recognizes agent-instructions user messages", () => {
+    const message: AthrdUserMessage = {
+      id: "u1",
+      type: "user",
+      content: "bootstrap",
+      variant: "agent-instructions",
+    };
+
+    expect(isAgentInstructionsUserMessage(message)).toBe(true);
+    expect(
+      isAgentInstructionsUserMessage({
+        ...message,
+        variant: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/codex-message-utils.ts
+++ b/apps/web/src/lib/codex-message-utils.ts
@@ -1,0 +1,15 @@
+import type { AthrdUserMessage } from "@/types/athrd";
+
+export const AGENT_INSTRUCTIONS_PREFIX = "# AGENTS.md instructions for ";
+
+export function isAgentInstructionsMessageContent(
+  content: string | undefined | null,
+): boolean {
+  return typeof content === "string" && content.startsWith(AGENT_INSTRUCTIONS_PREFIX);
+}
+
+export function isAgentInstructionsUserMessage(
+  message: AthrdUserMessage | undefined,
+): boolean {
+  return message?.variant === "agent-instructions";
+}

--- a/apps/web/src/lib/thread-loader.test.ts
+++ b/apps/web/src/lib/thread-loader.test.ts
@@ -227,4 +227,79 @@ describe("thread-loader", () => {
     });
     expect(context.record.createdAt).toBe("2026-03-03T00:00:00.000Z");
   });
+
+  it("ignores agent instructions when falling back to the first user message for title", () => {
+    const context = parseThreadContextFromSourceRecord({
+      id: "S-threads/codex.json",
+      source: "s3",
+      sourceId: "threads/codex.json",
+      filename: "codex.json",
+      content: JSON.stringify({
+        __athrd: {
+          ide: "codex",
+        },
+        sessionId: "session_1",
+        timestamp: "2026-03-03T00:00:00.000Z",
+        type: "message",
+        payload: {
+          id: "session_1",
+          timestamp: "2026-03-03T00:00:00.000Z",
+          cwd: "/repo",
+          originator: "codex",
+          cli_version: "1.0.0",
+          instructions: null,
+          source: "cli",
+          model_provider: "openai",
+          git: {
+            commit_hash: "deadbeef",
+            branch: "main",
+            repository_url: "https://github.com/athrd-com/athrd",
+          },
+        },
+        messages: [
+          {
+            timestamp: "2026-03-03T00:00:00.000Z",
+            type: "event_msg",
+            payload: {
+              type: "task_started",
+            },
+          },
+          {
+            timestamp: "2026-03-03T00:00:01.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: "# AGENTS.md instructions for /Users/example/project\n\n<INSTRUCTIONS>...</INSTRUCTIONS>",
+                },
+              ],
+            },
+          },
+          {
+            timestamp: "2026-03-03T00:00:02.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: "Real title source",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(context.parsedThread.messages[0]).toMatchObject({
+      type: "user",
+      variant: "agent-instructions",
+    });
+    expect(context.title).toBe("Real title source");
+  });
 });

--- a/apps/web/src/lib/thread-loader.ts
+++ b/apps/web/src/lib/thread-loader.ts
@@ -1,5 +1,5 @@
 import { detectIDE, parseThread } from "@/parsers";
-import type { AThrd } from "@/types/athrd";
+import type { AThrd, AthrdUserMessage } from "@/types/athrd";
 import type { ClaudeThread as ClaudeThreadType } from "@/types/claude";
 import type { CodexThread as CodexThreadType } from "@/types/codex";
 import type { GeminiThread as GeminiThreadType } from "@/types/gemini";
@@ -13,6 +13,7 @@ import {
   type ThreadSourceOwner,
   type ThreadSourceRecord,
 } from "./thread-source";
+import { isAgentInstructionsUserMessage } from "./codex-message-utils";
 
 export type ThreadLoadErrorCode =
   | "NOT_FOUND"
@@ -215,7 +216,10 @@ function extractOwnerFromRawContent(
 }
 
 function getFirstUserMessageContent(thread: AThrd): string | undefined {
-  const firstUserMessage = thread.messages.find((message) => message.type === "user");
+  const firstUserMessage = thread.messages.find(
+    (message): message is AthrdUserMessage =>
+      message.type === "user" && !isAgentInstructionsUserMessage(message),
+  );
   if (!firstUserMessage || !firstUserMessage.content.trim()) {
     return undefined;
   }

--- a/apps/web/src/parsers/codex.test.ts
+++ b/apps/web/src/parsers/codex.test.ts
@@ -280,6 +280,50 @@ describe("codexParser", () => {
       expect(result.messages[0]?.content).toBe("Real user message");
     });
 
+    it("marks AGENTS.md bootstrap messages for collapsed display", () => {
+      const thread = createBaseThread();
+      thread.messages = [
+        createTaskStartedEvent(),
+        {
+          timestamp: "2024-01-07T12:00:00Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "# AGENTS.md instructions for /Users/example/project\n\n<INSTRUCTIONS>...</INSTRUCTIONS>",
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2024-01-07T12:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Real user message" }],
+          },
+        },
+      ];
+
+      const result = codexParser.parse(thread);
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0]).toMatchObject({
+        type: "user",
+        content:
+          "# AGENTS.md instructions for /Users/example/project\n\n<INSTRUCTIONS>...</INSTRUCTIONS>",
+        variant: "agent-instructions",
+      });
+      expect(result.messages[1]).toMatchObject({
+        type: "user",
+        content: "Real user message",
+      });
+    });
+
     it("should skip empty user messages", () => {
       const thread = createBaseThread();
       thread.messages = [

--- a/apps/web/src/parsers/codex.ts
+++ b/apps/web/src/parsers/codex.ts
@@ -19,6 +19,7 @@ import type {
   CodexTurnContextMessage,
 } from "@/types/codex";
 import { IDE } from "@/types/ide";
+import { isAgentInstructionsMessageContent } from "@/lib/codex-message-utils";
 import type { Parser } from "./base";
 import {
   createMCPToolCall,
@@ -159,6 +160,9 @@ function handleResponseMessage(
       id: createStableCodexMessageId("user", timestamp, String(sourceIndex)),
       type: "user",
       content: textContent,
+      variant: isAgentInstructionsMessageContent(textContent)
+        ? "agent-instructions"
+        : undefined,
     });
     return;
   }

--- a/apps/web/src/types/athrd.ts
+++ b/apps/web/src/types/athrd.ts
@@ -17,6 +17,7 @@ export interface AthrdUserMessage {
   id: string;
   type: "user";
   content: string;
+  variant?: "agent-instructions";
   variables?: Array<
     AthrdUserMessageFileVariable | AthrdUserMessageImageVariable
   >;

--- a/apps/web/src/types/codex.ts
+++ b/apps/web/src/types/codex.ts
@@ -45,10 +45,18 @@ export interface CodexEventMessage {
   timestamp: string;
   type: "event_msg";
   payload:
+    | CodexTaskStartedEvent
     | CodexAgentMessageEvent
     | CodexAgentReasoningEvent
     | CodexUserMessageEvent
     | CodexTokenCountPayload;
+}
+
+export interface CodexTaskStartedEvent {
+  type: "task_started";
+  turn_id?: string;
+  model_context_window?: number;
+  collaboration_mode_kind?: string;
 }
 
 export interface CodexAgentMessageEvent {


### PR DESCRIPTION
## Summary
- Mark Codex `# AGENTS.md instructions for ...` bootstrap messages as agent instructions.
- Collapse leading agent-instruction user messages into the same visual group as the real prompt.
- Ignore agent instructions when deriving the fallback thread title.

## Testing
- `npm test -- components/thread/user-message-group-utils.test.ts parsers/codex.test.ts lib/thread-loader.test.ts --run`
- `./node_modules/.bin/tsc --noEmit`

---
# Agent Session(s)
- https://athrd.com/threads/67dc68c1952dbb4f1d135bee17372703