### PR TITLE
Fix Codex user input image rendering

### DIFF
--- a/apps/web/src/parsers/codex.test.ts
+++ b/apps/web/src/parsers/codex.test.ts
@@ -190,6 +190,48 @@ describe("codexParser", () => {
       expect(result.messages[0]?.content).toBe("First part\nSecond part");
     });
 
+    it("renders inline user input images from Codex content blocks", () => {
+      const thread = createBaseThread();
+      thread.messages = [
+        createTaskStartedEvent(),
+        {
+          timestamp: "2026-03-16T18:52:44.497Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "It should be collapsed into a single group,\n",
+              },
+              {
+                type: "input_text",
+                text: "<image>",
+              },
+              {
+                type: "input_image",
+                image_url: "data:image/png;base64,base64imagedata",
+              },
+              {
+                type: "input_text",
+                text: "</image>",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = codexParser.parse(thread);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]).toMatchObject({
+        type: "user",
+        content:
+          "It should be collapsed into a single group,\n\n![User image 1](data:image/png;base64,base64imagedata)",
+      });
+    });
+
     it("should skip user and assistant messages before task_started", () => {
       const thread = createBaseThread();
       thread.messages = [

--- a/apps/web/src/parsers/codex.ts
+++ b/apps/web/src/parsers/codex.ts
@@ -11,7 +11,9 @@ import type {
 import type {
   CodexFunctionCallOutputPayload,
   CodexFunctionCallPayload,
+  CodexInputImageContent,
   CodexMessage,
+  CodexMessageContent,
   CodexReasoningPayload,
   CodexResponseItem,
   CodexResponseMessagePayload,
@@ -131,12 +133,54 @@ function ensureAssistantId(
 // ─────────────────────────────────────────────────────────────────────────────
 
 function extractTextContent(
-  content: Array<{ type: string; text: string }>,
+  content: Array<{ type: string; text?: string }>,
   textType: string
 ): string {
   return content
-    .filter((c) => c.type === textType)
+    .filter((c): c is { type: string; text: string } => {
+      return c.type === textType && typeof c.text === "string";
+    })
     .map((c) => c.text)
+    .join("\n");
+}
+
+function stripCodexImageDelimiters(text: string, hasInlineImage: boolean): string {
+  if (!hasInlineImage) {
+    return text;
+  }
+
+  return text.replaceAll("<image>", "").replaceAll("</image>", "");
+}
+
+function renderCodexImageMarkdown(
+  content: CodexInputImageContent,
+  imageIndex: number
+): string {
+  return `![User image ${imageIndex}](${content.image_url})`;
+}
+
+function extractUserContent(content: CodexMessageContent[]): string {
+  const hasInlineImage = content.some((item) => item.type === "input_image");
+  let imageIndex = 0;
+
+  return content
+    .map((item) => {
+      if (item.type === "input_text") {
+        const cleanedText = stripCodexImageDelimiters(
+          item.text,
+          hasInlineImage
+        );
+        return cleanedText.trim().length > 0 ? cleanedText : null;
+      }
+
+      if (item.type === "input_image") {
+        imageIndex += 1;
+        return renderCodexImageMarkdown(item, imageIndex);
+      }
+
+      return null;
+    })
+    .filter((item): item is string => item !== null)
     .join("\n");
 }
 
@@ -150,7 +194,7 @@ function handleResponseMessage(
 
   if (payload.role === "user") {
     flushAssistant(ctx);
-    const textContent = extractTextContent(payload.content, "input_text");
+    const textContent = extractUserContent(payload.content);
     if (!textContent.trim()) return;
 
     // Skip environment context messages

--- a/apps/web/src/types/codex.ts
+++ b/apps/web/src/types/codex.ts
@@ -122,7 +122,8 @@ export interface CodexResponseMessagePayload {
 
 export type CodexMessageContent =
   | CodexInputTextContent
-  | CodexOutputTextContent;
+  | CodexOutputTextContent
+  | CodexInputImageContent;
 
 export interface CodexInputTextContent {
   type: "input_text";
@@ -132,6 +133,11 @@ export interface CodexInputTextContent {
 export interface CodexOutputTextContent {
   type: "output_text";
   text: string;
+}
+
+export interface CodexInputImageContent {
+  type: "input_image";
+  image_url: string;
 }
 
 export interface CodexFunctionCallPayload {
@@ -147,8 +153,8 @@ export interface CodexFunctionCallOutputPayload {
   output:
     | string
     | Array<
-        | { type: "input_text"; text: string }
-        | { type: "input_image"; image_url: string }
+        | CodexInputTextContent
+        | CodexInputImageContent
       >;
 }
 


### PR DESCRIPTION
## Summary
- parse Codex user `input_image` content blocks inline with surrounding user text
- strip Codex `<image>` delimiters and emit markdown images so the existing thread renderer displays them
- add a regression test covering the issue payload shape

## Testing
- pnpm exec vitest run src/parsers/codex.test.ts
- pnpm exec tsc --noEmit -p tsconfig.json

Closes #51

---
# Agent Session(s)
- https://athrd.com/threads/efdb945d7effeb47fe1c68175a8aa01c