### PR TITLE
Fix GitHub org switcher redirect flow

### DIFF
--- a/apps/web/src/app/threads/org-switcher.tsx
+++ b/apps/web/src/app/threads/org-switcher.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
-import { authClient } from "~/server/better-auth/client";
+import { refreshGithubOrganizations } from "~/lib/github-auth";
 
 interface OrganizationOption {
   id: string;
@@ -67,10 +67,9 @@ export function OrgSwitcher({
             setIsRefreshing(true);
 
             try {
-              await authClient.signIn.social({
-                provider: "github",
-                callbackURL: "/threads",
-              });
+              await refreshGithubOrganizations();
+            } catch (error) {
+              console.error("Failed to refresh GitHub organizations", error);
             } finally {
               setIsRefreshing(false);
             }

--- a/apps/web/src/components/auth/login-button.tsx
+++ b/apps/web/src/components/auth/login-button.tsx
@@ -3,7 +3,7 @@
 import { Github, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
-import { authClient } from "~/server/better-auth/client";
+import { startGithubSignIn } from "~/lib/github-auth";
 
 export function LoginButton() {
   const [isLoading, setIsLoading] = useState(false);
@@ -11,10 +11,9 @@ export function LoginButton() {
   const handleLogin = async () => {
     setIsLoading(true);
     try {
-      await authClient.signIn.social({
-        provider: "github",
-        callbackURL: "/threads",
-      });
+      await startGithubSignIn();
+    } catch (error) {
+      console.error("Failed to start GitHub sign-in", error);
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/lib/github-auth.test.ts
+++ b/apps/web/src/lib/github-auth.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { locationAssignMock, signInSocialMock, linkSocialMock } = vi.hoisted(
+  () => ({
+    locationAssignMock: vi.fn(),
+    signInSocialMock: vi.fn(),
+    linkSocialMock: vi.fn(),
+  }),
+);
+
+vi.mock("~/server/better-auth/client", () => ({
+  authClient: {
+    signIn: {
+      social: signInSocialMock,
+    },
+    linkSocial: linkSocialMock,
+  },
+}));
+
+import {
+  refreshGithubOrganizations,
+  startGithubSignIn,
+} from "./github-auth";
+
+describe("lib/github-auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("window", {
+      location: {
+        assign: locationAssignMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("starts GitHub sign-in with an explicit redirect", async () => {
+    signInSocialMock.mockResolvedValue({
+      data: {
+        url: "https://github.com/login/oauth/authorize",
+      },
+      error: null,
+    });
+
+    await startGithubSignIn();
+
+    expect(signInSocialMock).toHaveBeenCalledWith({
+      provider: "github",
+      callbackURL: "/threads",
+      disableRedirect: true,
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith(
+      "https://github.com/login/oauth/authorize",
+    );
+  });
+
+  it("relinks GitHub before refreshing organizations", async () => {
+    linkSocialMock.mockResolvedValue({
+      data: {
+        url: "https://github.com/settings/connections/applications/example",
+      },
+      error: null,
+    });
+
+    await refreshGithubOrganizations();
+
+    expect(linkSocialMock).toHaveBeenCalledWith({
+      provider: "github",
+      callbackURL: "/threads",
+      disableRedirect: true,
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith(
+      "https://github.com/settings/connections/applications/example",
+    );
+  });
+
+  it("throws when the auth flow does not return a redirect URL", async () => {
+    linkSocialMock.mockResolvedValue({
+      data: {
+        url: undefined,
+      },
+      error: null,
+    });
+
+    await expect(refreshGithubOrganizations()).rejects.toThrow(
+      "Unable to refresh GitHub organizations.",
+    );
+    expect(locationAssignMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/github-auth.ts
+++ b/apps/web/src/lib/github-auth.ts
@@ -1,0 +1,61 @@
+import { authClient } from "~/server/better-auth/client";
+
+const THREADS_CALLBACK_URL = "/threads";
+
+interface AuthRedirectResult {
+  data: {
+    url?: string;
+  } | null;
+  error: {
+    message?: string;
+  } | null;
+}
+
+function getRedirectUrl(
+  result: AuthRedirectResult,
+  fallbackMessage: string,
+): string {
+  if (result.error) {
+    throw new Error(result.error.message ?? fallbackMessage);
+  }
+
+  const redirectUrl = result.data?.url;
+
+  if (!redirectUrl) {
+    throw new Error(fallbackMessage);
+  }
+
+  return redirectUrl;
+}
+
+async function startGithubFlow(
+  request: Promise<AuthRedirectResult>,
+  fallbackMessage: string,
+) {
+  const result = await request;
+
+  // Navigate explicitly instead of relying on the auth client's redirect hook.
+  window.location.assign(getRedirectUrl(result, fallbackMessage));
+}
+
+export function startGithubSignIn() {
+  return startGithubFlow(
+    authClient.signIn.social({
+      provider: "github",
+      callbackURL: THREADS_CALLBACK_URL,
+      disableRedirect: true,
+    }),
+    "Unable to start GitHub sign-in.",
+  );
+}
+
+export function refreshGithubOrganizations() {
+  return startGithubFlow(
+    authClient.linkSocial({
+      provider: "github",
+      callbackURL: THREADS_CALLBACK_URL,
+      disableRedirect: true,
+    }),
+    "Unable to refresh GitHub organizations.",
+  );
+}


### PR DESCRIPTION
## Summary
- replace implicit Better Auth redirect handling with an explicit browser redirect helper
- use the signed-in GitHub relink flow for the org switcher's "I don't see it" action so users are sent back to GitHub to refresh org access
- reuse the same redirect helper for the main GitHub login button and cover it with focused tests

## Testing
- `bunx tsc --noEmit`
- `bunx vitest run src/lib/github-auth.test.ts`

---
# Agent Session(s)
- https://athrd.com/threads/2dc324daa29f680fe7b2f0cde86d3b08