### PR TITLE
[codex] Add Pi thread support

### DIFF
--- a/apps/web/src/components/home/HeroSection.tsx
+++ b/apps/web/src/components/home/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import { ClaudeAiIcon } from "@/components/ui/svgs/claudeAiIcon";
 import { Openai } from "@/components/ui/svgs/openai";
+import { Pi } from "@/components/ui/svgs/pi";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Gemini } from "../ui/svgs/gemini";
@@ -38,6 +39,7 @@ export function HeroSection() {
           fill="currentColor"
         />
       ),
+      supportIcon: <ClaudeAiIcon className="h-5 w-5" />,
     },
     {
       name: "Codex",
@@ -47,6 +49,9 @@ export function HeroSection() {
           className="w-8 h-8 md:w-10 md:h-10 text-white"
           fill="currentColor"
         />
+      ),
+      supportIcon: (
+        <Openai className="h-5 w-5 text-white" fill="currentColor" />
       ),
     },
     {
@@ -58,6 +63,13 @@ export function HeroSection() {
           fill="currentColor"
         />
       ),
+      supportIcon: <Gemini className="h-5 w-5" />,
+    },
+    {
+      name: "Pi",
+      color: "from-violet-500 to-cyan-400",
+      icon: <Pi className="w-8 h-8 md:w-10 md:h-10 text-white" />,
+      supportIcon: <Pi className="h-5 w-5 text-white" />,
     },
   ];
 
@@ -158,16 +170,7 @@ export function HeroSection() {
                 className="flex items-center gap-3 px-3 py-1.5 text-sm text-gray-200"
               >
                 <span className="flex h-8 w-8 items-center justify-center rounded-full bg-black/40 ring-1 ring-white/10">
-                  {brand.name === "Gemini" ? (
-                    <Gemini className="h-5 w-5" />
-                  ) : brand.name === "Codex" ? (
-                    <Openai
-                      className="h-5 w-5 text-white"
-                      fill="currentColor"
-                    />
-                  ) : (
-                    <ClaudeAiIcon className="h-5 w-5" />
-                  )}
+                  {brand.supportIcon}
                 </span>
                 <span>{brand.name}</span>
               </div>

--- a/apps/web/src/components/thread/thread-header.tsx
+++ b/apps/web/src/components/thread/thread-header.tsx
@@ -39,6 +39,8 @@ function getIDEIcon(ide?: IDE) {
       return <OpenaiDark className="h-6 w-6" />;
     case IDE.CURSOR:
       return <CursorWordmarkLight className="h-6 w-6" />;
+    case IDE.PI:
+      return null;
     default:
       return null;
   }
@@ -56,6 +58,8 @@ function getIDEName(ide?: IDE) {
       return "Codex";
     case IDE.CURSOR:
       return "Cursor";
+    case IDE.PI:
+      return "Pi";
     default:
       return null;
   }

--- a/apps/web/src/components/ui/svgs/pi.tsx
+++ b/apps/web/src/components/ui/svgs/pi.tsx
@@ -1,26 +1,15 @@
 import type { SVGProps } from "react";
 
 const Pi = (props: SVGProps<SVGSVGElement>) => (
-  <svg {...props} fill="none" viewBox="0 0 100 100">
+  <svg {...props} viewBox="0 0 800 800">
     <path
-      d="M18 28h64"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeWidth="12"
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
     />
     <path
-      d="M36 28v44c0 7.2-4.8 12-12 12"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="12"
-    />
-    <path
-      d="M64 28v44c0 7.2 4.8 12 12 12"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="12"
+      fill="currentColor"
+      d="M517.36 400H634.72V634.72H517.36Z"
     />
   </svg>
 );

--- a/apps/web/src/components/ui/svgs/pi.tsx
+++ b/apps/web/src/components/ui/svgs/pi.tsx
@@ -1,0 +1,28 @@
+import type { SVGProps } from "react";
+
+const Pi = (props: SVGProps<SVGSVGElement>) => (
+  <svg {...props} fill="none" viewBox="0 0 100 100">
+    <path
+      d="M18 28h64"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="12"
+    />
+    <path
+      d="M36 28v44c0 7.2-4.8 12-12 12"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="12"
+    />
+    <path
+      d="M64 28v44c0 7.2 4.8 12 12 12"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="12"
+    />
+  </svg>
+);
+
+export { Pi };

--- a/apps/web/src/lib/thread-loader.ts
+++ b/apps/web/src/lib/thread-loader.ts
@@ -4,6 +4,7 @@ import type { ClaudeThread as ClaudeThreadType } from "@/types/claude";
 import type { CodexThread as CodexThreadType } from "@/types/codex";
 import type { GeminiThread as GeminiThreadType } from "@/types/gemini";
 import { IDE } from "@/types/ide";
+import type { PiThread as PiThreadType } from "@/types/pi";
 import type { VSCodeThread as IVSCodeThread } from "@/types/vscode";
 import type { GistData, GistFile } from "~/lib/github";
 import {
@@ -323,6 +324,31 @@ function extractModelsUsed(
           models.add(
             [msg.payload.model, msg.payload.effort].filter(Boolean).join("-"),
           );
+        }
+      });
+    }
+
+    if (ide === IDE.PI) {
+      const piContent = content as unknown as PiThreadType;
+      const entries = piContent.entries ?? piContent.messages ?? [];
+      entries.forEach((entry) => {
+        if (entry.type === "model_change") {
+          const modelId = (entry as { modelId?: unknown }).modelId;
+          if (typeof modelId === "string" && modelId.trim()) {
+            models.add(modelId);
+          }
+        }
+
+        if (entry.type === "message") {
+          const message = (entry as { message?: unknown }).message;
+          if (!isRecord(message) || message.role !== "assistant") {
+            return;
+          }
+
+          const model = message.model;
+          if (typeof model === "string" && model.trim()) {
+            models.add(model);
+          }
         }
       });
     }

--- a/apps/web/src/parsers/index.ts
+++ b/apps/web/src/parsers/index.ts
@@ -7,6 +7,7 @@ import { claudeParser } from "./claude";
 import { codexParser } from "./codex";
 import { cursorParser } from "./cursor";
 import { geminiParser } from "./gemini";
+import { piParser } from "./pi";
 import { vscodeParser } from "./vscode";
 
 // Export individual parsers
@@ -14,6 +15,7 @@ export { claudeParser } from "./claude";
 export { codexParser } from "./codex";
 export { cursorParser } from "./cursor";
 export { geminiParser } from "./gemini";
+export { piParser } from "./pi";
 export { vscodeParser } from "./vscode";
 
 // Export base types and utilities
@@ -43,6 +45,7 @@ export const parsers: Record<IDE, Parser> = {
   [IDE.CODEX]: codexParser,
   [IDE.VSCODE]: vscodeParser,
   [IDE.CURSOR]: cursorParser,
+  [IDE.PI]: piParser,
 };
 
 /**
@@ -54,6 +57,7 @@ const parserList: Parser[] = [
   codexParser,
   vscodeParser,
   cursorParser,
+  piParser,
 ];
 
 /**

--- a/apps/web/src/parsers/pi.test.ts
+++ b/apps/web/src/parsers/pi.test.ts
@@ -20,6 +20,19 @@ describe("piParser", () => {
       expect(piParser.canParse(thread)).toBe(true);
     });
 
+    it("identifies raw Pi JSONL session headers without sessionId", () => {
+      expect(
+        piParser.canParse({
+          type: "session",
+          version: 3,
+          id: "019dd768-665c-7732-9503-55e7b465009c",
+          timestamp: "2026-04-29T04:03:56.636Z",
+          cwd: "/Users/gregorymarcilhacy/code/athrd",
+          entries: [],
+        }),
+      ).toBe(true);
+    });
+
     it("rejects unrelated structures", () => {
       expect(piParser.canParse(null)).toBe(false);
       expect(piParser.canParse({})).toBe(false);
@@ -76,6 +89,225 @@ describe("piParser", () => {
       id: "asst0001",
       type: "assistant",
       content: "Hello world!",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("maps the observed Pi JSONL session fields", () => {
+    const toolCallId =
+      "call_Q6UCYwz4TyQc69jFhHkoFxny|fc_00f8285a1f5191860169f1834310988193a39e6de2ae043aa6";
+    const thread: PiThread = {
+      type: "session",
+      version: 3,
+      id: "019dd768-665c-7732-9503-55e7b465009c",
+      timestamp: "2026-04-29T04:03:56.636Z",
+      cwd: "/Users/gregorymarcilhacy/code/athrd",
+      entries: [
+        {
+          type: "model_change",
+          id: "65e73f9f",
+          parentId: null,
+          timestamp: "2026-04-29T04:04:02.875Z",
+          provider: "openai-codex",
+          modelId: "gpt-5.4",
+        },
+        {
+          type: "thinking_level_change",
+          id: "1713a56e",
+          parentId: "65e73f9f",
+          timestamp: "2026-04-29T04:04:02.876Z",
+          thinkingLevel: "medium",
+        },
+        {
+          type: "message",
+          id: "98cc6cd0",
+          parentId: "1713a56e",
+          timestamp: "2026-04-29T04:04:06.786Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Hello" }],
+            timestamp: 1777435446783,
+          },
+        },
+        {
+          type: "message",
+          id: "08c7da16",
+          parentId: "98cc6cd0",
+          timestamp: "2026-04-29T04:04:08.214Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "Hello! How can I help?",
+                textSignature:
+                  '{"v":1,"id":"msg_00f8285a1f5191860169f18337e6008193a9a1d01a1cbe7dda","phase":"final_answer"}',
+              },
+            ],
+            api: "openai-codex-responses",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            usage: {
+              input: 1531,
+              output: 11,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 1542,
+              cost: {
+                input: 0.0038275,
+                output: 0.000165,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0.0039925,
+              },
+            },
+            stopReason: "stop",
+            timestamp: 1777435446794,
+            responseId: "resp_00f8285a1f5191860169f183373fcc81939f264eb23932aa1d",
+          },
+        },
+        {
+          type: "message",
+          id: "a160bf57",
+          parentId: "08c7da16",
+          timestamp: "2026-04-29T04:04:15.584Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "How many folders are in there?" }],
+            timestamp: 1777435455583,
+          },
+        },
+        {
+          type: "message",
+          id: "da0a1c46",
+          parentId: "a160bf57",
+          timestamp: "2026-04-29T04:04:19.268Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: "**Figuring out current directory**",
+                thinkingSignature:
+                  '{"id":"rs_00f8285a1f5191860169f1834134f88193a03c4ab86793dc49","type":"reasoning"}',
+              },
+              {
+                type: "toolCall",
+                id: toolCallId,
+                name: "bash",
+                arguments: {
+                  command: "find . -maxdepth 1 -mindepth 1 -type d | wc -l",
+                },
+              },
+            ],
+            api: "openai-codex-responses",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            usage: {
+              input: 531,
+              output: 64,
+              cacheRead: 1024,
+              cacheWrite: 0,
+              totalTokens: 1619,
+              cost: {
+                input: 0.0013275000000000001,
+                output: 0.00096,
+                cacheRead: 0.000256,
+                cacheWrite: 0,
+                total: 0.0025435,
+              },
+            },
+            stopReason: "toolUse",
+            timestamp: 1777435455585,
+            responseId: "resp_00f8285a1f5191860169f1833fd2408193a0cd284fc315d487",
+          },
+        },
+        {
+          type: "message",
+          id: "34ce9aae",
+          parentId: "da0a1c46",
+          timestamp: "2026-04-29T04:04:19.294Z",
+          message: {
+            role: "toolResult",
+            toolCallId,
+            toolName: "bash",
+            content: [{ type: "text", text: "      10\n" }],
+            isError: false,
+            timestamp: 1777435459294,
+          },
+        },
+        {
+          type: "message",
+          id: "16b43ef2",
+          parentId: "34ce9aae",
+          timestamp: "2026-04-29T04:04:20.607Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "There are 10 folders in `/Users/gregorymarcilhacy/code/athrd`.",
+                textSignature:
+                  '{"v":1,"id":"msg_00f8285a1f5191860169f183441cf481938fa27c46e57991ef","phase":"final_answer"}',
+              },
+            ],
+            api: "openai-codex-responses",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            usage: {
+              input: 610,
+              output: 24,
+              cacheRead: 1024,
+              cacheWrite: 0,
+              totalTokens: 1658,
+              cost: {
+                input: 0.001525,
+                output: 0.00036,
+                cacheRead: 0.000256,
+                cacheWrite: 0,
+                total: 0.002141,
+              },
+            },
+            stopReason: "stop",
+            timestamp: 1777435459295,
+            responseId: "resp_00f8285a1f5191860169f183438ac88193a713502335a8a99e",
+          },
+        },
+      ],
+    };
+
+    const result = piParser.parse(thread);
+    const toolCallMessage = result.messages[3] as AthrdAssistantMessage;
+
+    expect(result.messages).toHaveLength(5);
+    expect(result.messages[0]).toMatchObject({
+      id: "98cc6cd0",
+      type: "user",
+      content: "Hello",
+    });
+    expect(result.messages[1]).toMatchObject({
+      id: "08c7da16",
+      type: "assistant",
+      content: "Hello! How can I help?",
+      model: "gpt-5.4",
+    });
+    expect(toolCallMessage.toolCalls?.[0]).toMatchObject({
+      id: toolCallId,
+      name: "terminal_command",
+      args: {
+        command: "find . -maxdepth 1 -mindepth 1 -type d | wc -l",
+      },
+      result: [
+        {
+          name: "bash",
+          output: { type: "text", text: "      10\n" },
+        },
+      ],
+    });
+    expect(result.messages[4]).toMatchObject({
+      id: "16b43ef2",
+      type: "assistant",
+      content: "There are 10 folders in `/Users/gregorymarcilhacy/code/athrd`.",
       model: "gpt-5.4",
     });
   });

--- a/apps/web/src/parsers/pi.test.ts
+++ b/apps/web/src/parsers/pi.test.ts
@@ -1,0 +1,358 @@
+import type { AthrdAssistantMessage } from "@/types/athrd";
+import type { PiThread } from "@/types/pi";
+import { describe, expect, it } from "vitest";
+import { piParser } from "./pi";
+
+const createBaseThread = (): PiThread => ({
+  sessionId: "019db56d-2567-7431-8f17-7946e4efd8eb",
+  type: "session",
+  version: 3,
+  id: "019db56d-2567-7431-8f17-7946e4efd8eb",
+  timestamp: "2026-04-22T13:42:02.343Z",
+  cwd: "/Users/example/project",
+  entries: [],
+});
+
+describe("piParser", () => {
+  describe("canParse", () => {
+    it("identifies Pi session exports", () => {
+      const thread = createBaseThread();
+      expect(piParser.canParse(thread)).toBe(true);
+    });
+
+    it("rejects unrelated structures", () => {
+      expect(piParser.canParse(null)).toBe(false);
+      expect(piParser.canParse({})).toBe(false);
+      expect(piParser.canParse({ type: "session", messages: "nope" })).toBe(false);
+    });
+  });
+
+  it("parses user and assistant text messages from Pi entries", () => {
+    const thread = createBaseThread();
+    thread.entries = [
+      {
+        type: "model_change",
+        id: "model001",
+        parentId: null,
+        timestamp: "2026-04-22T13:42:35.958Z",
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+      },
+      {
+        type: "message",
+        id: "user0001",
+        parentId: "model001",
+        timestamp: "2026-04-22T13:42:50.829Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "HEllo world!" }],
+          timestamp: 1776865370826,
+        },
+      },
+      {
+        type: "message",
+        id: "asst0001",
+        parentId: "user0001",
+        timestamp: "2026-04-22T13:42:51.939Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world!" }],
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          timestamp: 1776865370833,
+        },
+      },
+    ];
+
+    const result = piParser.parse(thread);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({
+      id: "user0001",
+      type: "user",
+      content: "HEllo world!",
+    });
+    expect(result.messages[1]).toMatchObject({
+      id: "asst0001",
+      type: "assistant",
+      content: "Hello world!",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("attaches tool results to assistant tool calls", () => {
+    const thread = createBaseThread();
+    thread.entries = [
+      {
+        type: "message",
+        id: "user0001",
+        parentId: null,
+        timestamp: "2026-04-22T13:42:50.829Z",
+        message: {
+          role: "user",
+          content: "List files",
+        },
+      },
+      {
+        type: "message",
+        id: "asst0001",
+        parentId: "user0001",
+        timestamp: "2026-04-22T13:42:51.939Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Need to inspect the directory." },
+            {
+              type: "toolCall",
+              id: "call_123",
+              name: "bash",
+              arguments: { command: "ls" },
+            },
+          ],
+          model: "gpt-5.4",
+        },
+      },
+      {
+        type: "message",
+        id: "tool0001",
+        parentId: "asst0001",
+        timestamp: "2026-04-22T13:42:52.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call_123",
+          toolName: "bash",
+          content: [{ type: "text", text: "README.md" }],
+          isError: false,
+        },
+      },
+    ];
+
+    const result = piParser.parse(thread);
+    const assistant = result.messages[1] as AthrdAssistantMessage;
+
+    expect(assistant.thoughts?.[0]).toMatchObject({
+      subject: "Thinking",
+      description: "Need to inspect the directory.",
+    });
+    expect(assistant.toolCalls?.[0]).toMatchObject({
+      id: "call_123",
+      name: "terminal_command",
+      args: {
+        command: "ls",
+      },
+      result: [
+        {
+          name: "bash",
+          output: { type: "text", text: "README.md" },
+        },
+      ],
+    });
+  });
+
+  it("parses the basic Pi session shape from an athrd workspace tool-call session", () => {
+    const toolCallId =
+      "call_rXJ84iiJ2nNaJf1bkHDKpODq|fc_054902127f4391cf0169e8e16b66688197bc072334b9ecb9b7";
+    const thread: PiThread = {
+      sessionId: "019db5b0-5765-740b-9c85-535e5009fd9b",
+      type: "session",
+      version: 3,
+      id: "019db5b0-5765-740b-9c85-535e5009fd9b",
+      timestamp: "2026-04-22T14:55:26.053Z",
+      cwd: "/Users/gregorymarcilhacy/code/athrd",
+      entries: [
+        {
+          type: "model_change",
+          id: "621b9d57",
+          parentId: null,
+          timestamp: "2026-04-22T14:55:26.067Z",
+          provider: "openai-codex",
+          modelId: "gpt-5.4",
+        },
+        {
+          type: "thinking_level_change",
+          id: "afaf23a3",
+          parentId: "621b9d57",
+          timestamp: "2026-04-22T14:55:26.067Z",
+          thinkingLevel: "medium",
+        },
+        {
+          type: "message",
+          id: "3ed89b7c",
+          parentId: "afaf23a3",
+          timestamp: "2026-04-22T14:55:35.575Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "list the folders in ~/.pi/" }],
+            timestamp: 1776869735571,
+          },
+        },
+        {
+          type: "message",
+          id: "87fb6f5c",
+          parentId: "3ed89b7c",
+          timestamp: "2026-04-22T14:55:39.602Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: "**Following command compliance**\n\nI need to run the folder listing with bash.",
+              },
+              {
+                type: "toolCall",
+                id: toolCallId,
+                name: "bash",
+                arguments: {
+                  command:
+                    "find ~/.pi -maxdepth 1 -mindepth 1 -type d -print | sort",
+                },
+              },
+            ],
+            api: "openai-codex-responses",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            stopReason: "toolUse",
+            timestamp: 1776869735580,
+          },
+        },
+        {
+          type: "message",
+          id: "4097b33f",
+          parentId: "87fb6f5c",
+          timestamp: "2026-04-22T14:55:39.616Z",
+          message: {
+            role: "toolResult",
+            toolCallId,
+            toolName: "bash",
+            content: [{ type: "text", text: "/Users/gregorymarcilhacy/.pi/agent\n" }],
+            isError: false,
+            timestamp: 1776869739616,
+          },
+        },
+        {
+          type: "message",
+          id: "814bd521",
+          parentId: "4097b33f",
+          timestamp: "2026-04-22T14:55:41.482Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "Folders in `~/.pi`:\n\n- `/Users/gregorymarcilhacy/.pi/agent`",
+              },
+            ],
+            api: "openai-codex-responses",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            stopReason: "stop",
+            timestamp: 1776869739618,
+          },
+        },
+      ],
+    };
+
+    const result = piParser.parse(thread);
+    const toolCallMessage = result.messages[1] as AthrdAssistantMessage;
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0]).toMatchObject({
+      id: "3ed89b7c",
+      type: "user",
+      content: "list the folders in ~/.pi/",
+    });
+    expect(toolCallMessage.thoughts?.[0]).toMatchObject({
+      subject: "Thinking",
+      description:
+        "**Following command compliance**\n\nI need to run the folder listing with bash.",
+    });
+    expect(toolCallMessage.toolCalls?.[0]).toMatchObject({
+      id: toolCallId,
+      name: "terminal_command",
+      args: {
+        command: "find ~/.pi -maxdepth 1 -mindepth 1 -type d -print | sort",
+      },
+      result: [
+        {
+          name: "bash",
+          output: {
+            type: "text",
+            text: "/Users/gregorymarcilhacy/.pi/agent\n",
+          },
+        },
+      ],
+    });
+    expect(result.messages[2]).toMatchObject({
+      id: "814bd521",
+      type: "assistant",
+      content: "Folders in `~/.pi`:\n\n- `/Users/gregorymarcilhacy/.pi/agent`",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("parses only the current Pi branch path", () => {
+    const thread = createBaseThread();
+    thread.entries = [
+      {
+        type: "message",
+        id: "user0001",
+        parentId: null,
+        timestamp: "2026-04-22T13:42:50.829Z",
+        message: { role: "user", content: "Root" },
+      },
+      {
+        type: "message",
+        id: "asst0001",
+        parentId: "user0001",
+        timestamp: "2026-04-22T13:42:51.939Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "First answer" }],
+        },
+      },
+      {
+        type: "message",
+        id: "olduser1",
+        parentId: "asst0001",
+        timestamp: "2026-04-22T13:43:00.000Z",
+        message: { role: "user", content: "Old branch" },
+      },
+      {
+        type: "message",
+        id: "oldasst1",
+        parentId: "olduser1",
+        timestamp: "2026-04-22T13:43:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Old branch answer" }],
+        },
+      },
+      {
+        type: "message",
+        id: "newuser1",
+        parentId: "asst0001",
+        timestamp: "2026-04-22T13:44:00.000Z",
+        message: { role: "user", content: "Current branch" },
+      },
+      {
+        type: "message",
+        id: "newasst1",
+        parentId: "newuser1",
+        timestamp: "2026-04-22T13:44:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Current branch answer" }],
+        },
+      },
+    ];
+
+    const result = piParser.parse(thread);
+
+    expect(result.messages.map((message) => message.id)).toEqual([
+      "user0001",
+      "asst0001",
+      "newuser1",
+      "newasst1",
+    ]);
+  });
+});

--- a/apps/web/src/parsers/pi.ts
+++ b/apps/web/src/parsers/pi.ts
@@ -1,0 +1,627 @@
+import type {
+  AThrd,
+  AthrdAssistantMessage,
+  AthrdThinking,
+  AthrdToolCall,
+  AthrdUserMessage,
+  BaseToolResponse,
+} from "@/types/athrd";
+import { IDE } from "@/types/ide";
+import type {
+  PiAgentMessage,
+  PiAssistantContent,
+  PiAssistantMessage,
+  PiBashExecutionMessage,
+  PiCompactionEntry,
+  PiCompactionSummaryMessage,
+  PiCustomMessage,
+  PiCustomMessageEntry,
+  PiEntry,
+  PiImageContent,
+  PiMessageEntry,
+  PiTextContent,
+  PiThread,
+  PiToolCallContent,
+  PiToolResultContent,
+  PiToolResultMessage,
+  PiUserContent,
+  PiUserMessage,
+} from "@/types/pi";
+import type { Parser } from "./base";
+import {
+  createListDirectoryToolCall,
+  createReadFileToolCall,
+  createReplaceToolCall,
+  createTerminalCommandToolCall,
+  createUnknownToolCall,
+  createWriteFileToolCall,
+  generateId,
+  mapToolName,
+  normalizeTimestamp,
+} from "./utils";
+
+type ToolResultMap = Map<string, PiToolResultMessage[]>;
+
+function getEntries(rawThread: PiThread): PiEntry[] {
+  if (Array.isArray(rawThread.entries)) {
+    return rawThread.entries;
+  }
+
+  if (Array.isArray(rawThread.messages)) {
+    return rawThread.messages;
+  }
+
+  return [];
+}
+
+function hasEntryId(entry: PiEntry): entry is PiEntry & { id: string } {
+  return typeof entry.id === "string" && entry.id.length > 0;
+}
+
+function selectCurrentBranch(entries: PiEntry[]): PiEntry[] {
+  const entriesById = new Map<string, PiEntry>();
+  for (const entry of entries) {
+    if (hasEntryId(entry)) {
+      entriesById.set(entry.id, entry);
+    }
+  }
+
+  let leaf: (PiEntry & { id: string }) | undefined;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry && hasEntryId(entry)) {
+      leaf = entry;
+      break;
+    }
+  }
+  if (!leaf) {
+    return entries;
+  }
+
+  const branch: PiEntry[] = [];
+  const seen = new Set<string>();
+  let current: PiEntry | undefined = leaf;
+
+  while (current && hasEntryId(current) && !seen.has(current.id)) {
+    seen.add(current.id);
+    branch.push(current);
+
+    const parentId: string | undefined =
+      typeof current.parentId === "string" && current.parentId.length > 0
+        ? current.parentId
+        : undefined;
+    current = parentId ? entriesById.get(parentId) : undefined;
+  }
+
+  return branch.reverse();
+}
+
+function buildToolResultMap(entries: PiEntry[]): ToolResultMap {
+  const resultMap: ToolResultMap = new Map();
+
+  for (const entry of entries) {
+    if (entry.type !== "message") continue;
+    const message = (entry as PiMessageEntry).message;
+    if (message.role !== "toolResult") continue;
+
+    const result = message as PiToolResultMessage;
+    const existing = resultMap.get(result.toolCallId) || [];
+    resultMap.set(result.toolCallId, [...existing, result]);
+  }
+
+  return resultMap;
+}
+
+function isTextContent(
+  content: PiUserContent | PiAssistantContent | PiToolResultContent
+): content is PiTextContent {
+  return content.type === "text";
+}
+
+function isImageContent(
+  content: PiUserContent | PiAssistantContent | PiToolResultContent
+): content is PiImageContent {
+  return content.type === "image";
+}
+
+function imageMarkdown(content: PiImageContent, index: number): string {
+  return `![Image ${index}](data:${content.mimeType};base64,${content.data})`;
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value == null) {
+    return "";
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractDisplayContent(content: string | PiUserContent[]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  let imageIndex = 0;
+  return content
+    .map((item) => {
+      if (isTextContent(item)) {
+        return item.text;
+      }
+
+      if (isImageContent(item)) {
+        imageIndex += 1;
+        return imageMarkdown(item, imageIndex);
+      }
+
+      return null;
+    })
+    .filter((item): item is string => item !== null && item.length > 0)
+    .join("\n");
+}
+
+function getMessageTimestamp(
+  entry: PiMessageEntry,
+  message: PiAgentMessage
+): string | number {
+  return message.timestamp ?? entry.timestamp;
+}
+
+function parseUserMessage(entry: PiMessageEntry): AthrdUserMessage | null {
+  const userMessage = entry.message as PiUserMessage;
+  const content = extractDisplayContent(userMessage.content);
+  if (!content.trim()) {
+    return null;
+  }
+
+  return {
+    id: entry.id || generateId(),
+    type: "user",
+    content,
+  };
+}
+
+function parseCustomMessage(
+  entry: PiMessageEntry,
+  message: PiCustomMessage
+): AthrdUserMessage | null {
+  if (message.display === false) {
+    return null;
+  }
+
+  const content = extractDisplayContent(message.content);
+  if (!content.trim()) {
+    return null;
+  }
+
+  return {
+    id: entry.id || generateId(),
+    type: "user",
+    content,
+  };
+}
+
+function parseCustomMessageEntry(
+  entry: PiCustomMessageEntry
+): AthrdUserMessage | null {
+  if (entry.display === false) {
+    return null;
+  }
+
+  const content = extractDisplayContent(entry.content);
+  if (!content.trim()) {
+    return null;
+  }
+
+  return {
+    id: entry.id || generateId(),
+    type: "user",
+    content,
+  };
+}
+
+function parseSummaryMessage(
+  id: string,
+  timestamp: string | number,
+  subject: string,
+  summary: string,
+  model?: string
+): AthrdAssistantMessage | null {
+  if (!summary.trim()) {
+    return null;
+  }
+
+  const normalizedTimestamp = normalizeTimestamp(timestamp);
+  return {
+    id,
+    type: "assistant",
+    timestamp: normalizedTimestamp,
+    thoughts: [
+      {
+        subject,
+        description: summary,
+        timestamp: normalizedTimestamp,
+      },
+    ],
+    model,
+  };
+}
+
+function parseAssistantMessage(
+  entry: PiMessageEntry,
+  message: PiAssistantMessage,
+  toolResults: ToolResultMap,
+  currentModel?: string
+): AthrdAssistantMessage | null {
+  const textContent: string[] = [];
+  const thoughts: AthrdThinking[] = [];
+  const toolCalls: AthrdToolCall[] = [];
+  const timestamp = getMessageTimestamp(entry, message);
+  const normalizedTimestamp = normalizeTimestamp(timestamp);
+
+  for (const content of message.content) {
+    if (content.type === "text" && content.text.trim()) {
+      textContent.push(content.text);
+    } else if (content.type === "image") {
+      textContent.push(imageMarkdown(content, textContent.length + 1));
+    } else if (content.type === "thinking" && content.thinking.trim()) {
+      thoughts.push({
+        subject: "Thinking",
+        description: content.thinking,
+        timestamp: normalizedTimestamp,
+      });
+    } else if (content.type === "toolCall") {
+      toolCalls.push(parseToolCall(content, normalizedTimestamp, toolResults));
+    }
+  }
+
+  if (
+    textContent.length === 0 &&
+    thoughts.length === 0 &&
+    toolCalls.length === 0 &&
+    !message.errorMessage
+  ) {
+    return null;
+  }
+
+  if (message.errorMessage) {
+    thoughts.push({
+      subject: "Error",
+      description: message.errorMessage,
+      timestamp: normalizedTimestamp,
+    });
+  }
+
+  return {
+    id: entry.id || generateId(),
+    type: "assistant",
+    content: textContent.join("\n\n"),
+    timestamp: normalizedTimestamp,
+    thoughts: thoughts.length > 0 ? thoughts : undefined,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    model: message.model || currentModel,
+  };
+}
+
+function parseBashExecutionMessage(
+  entry: PiMessageEntry,
+  message: PiBashExecutionMessage
+): AthrdAssistantMessage {
+  const timestamp = normalizeTimestamp(getMessageTimestamp(entry, message));
+  const outputText = message.output || "";
+  const result: BaseToolResponse[] = [
+    {
+      id: generateId(),
+      name: "bash",
+      ...(message.exitCode && message.exitCode !== 0
+        ? { error: outputText }
+        : { output: { type: "text" as const, text: outputText } }),
+    },
+  ];
+
+  return {
+    id: entry.id || generateId(),
+    type: "assistant",
+    timestamp,
+    toolCalls: [
+      createTerminalCommandToolCall({
+        id: entry.id || generateId(),
+        timestamp,
+        command: message.command,
+        result,
+      }),
+    ],
+  };
+}
+
+function parseToolResultResponses(
+  toolName: string,
+  results: PiToolResultMessage[]
+): BaseToolResponse[] {
+  const responses: BaseToolResponse[] = [];
+
+  for (const result of results) {
+    let hasContent = false;
+
+    for (const content of result.content || []) {
+      hasContent = true;
+
+      if (isTextContent(content)) {
+        responses.push({
+          id: generateId(),
+          name: result.toolName || toolName,
+          ...(result.isError
+            ? { error: content.text }
+            : { output: { type: "text" as const, text: content.text } }),
+        });
+      } else if (isImageContent(content)) {
+        responses.push({
+          id: generateId(),
+          name: result.toolName || toolName,
+          output: {
+            type: "image",
+            data: content.data,
+            mimeType: content.mimeType,
+          },
+        });
+      }
+    }
+
+    if (!hasContent && result.details !== undefined) {
+      responses.push({
+        id: generateId(),
+        name: result.toolName || toolName,
+        ...(result.isError
+          ? { error: stringifyValue(result.details) }
+          : {
+              output: {
+                type: "text" as const,
+                text: stringifyValue(result.details),
+              },
+            }),
+      });
+    }
+  }
+
+  return responses;
+}
+
+function getStringArg(
+  args: Record<string, unknown>,
+  keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function parseToolCall(
+  toolCall: PiToolCallContent,
+  timestamp: string,
+  toolResults: ToolResultMap
+): AthrdToolCall {
+  const canonicalName = mapToolName(IDE.PI, toolCall.name);
+  const args = toolCall.arguments || {};
+  const result = parseToolResultResponses(
+    toolCall.name,
+    toolResults.get(toolCall.id) || []
+  );
+
+  switch (canonicalName) {
+    case "read_file":
+      return createReadFileToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        filePath:
+          getStringArg(args, ["file_path", "filePath", "path", "file"]) || "",
+        result,
+      });
+    case "write_file":
+      return createWriteFileToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        filePath:
+          getStringArg(args, ["file_path", "filePath", "path", "file"]) || "",
+        content: getStringArg(args, ["content", "text"]) || "",
+        result,
+      });
+    case "replace":
+      return createReplaceToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        filePath:
+          getStringArg(args, ["file_path", "filePath", "path", "file"]) || "",
+        oldString:
+          getStringArg(args, ["old_string", "oldString", "oldText"]) || "",
+        newString:
+          getStringArg(args, ["new_string", "newString", "newText"]) || "",
+        result,
+      });
+    case "terminal_command":
+      return createTerminalCommandToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        command: getStringArg(args, ["command", "cmd", "shell"]) || "",
+        cwd: getStringArg(args, ["cwd"]),
+        result,
+      });
+    case "ls":
+      return createListDirectoryToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        dirPath: getStringArg(args, ["dir_path", "dirPath", "path", "dir"]) || "",
+        result,
+      });
+    default:
+      return createUnknownToolCall({
+        id: toolCall.id || generateId(),
+        timestamp,
+        name: toolCall.name,
+        args,
+        result,
+      });
+  }
+}
+
+function isPiThreadShape(thread: Record<string, unknown>): boolean {
+  const entries = Array.isArray(thread.entries)
+    ? thread.entries
+    : thread.messages;
+
+  return (
+    thread.type === "session" &&
+    Array.isArray(entries) &&
+    (typeof thread.sessionId === "string" ||
+      typeof thread.id === "string" ||
+      typeof thread.cwd === "string" ||
+      typeof thread.version === "number")
+  );
+}
+
+export const piParser: Parser<PiThread> = {
+  id: IDE.PI,
+
+  canParse(rawThread: unknown): rawThread is PiThread {
+    if (!rawThread || typeof rawThread !== "object") return false;
+    return isPiThreadShape(rawThread as Record<string, unknown>);
+  },
+
+  parse(rawThread: PiThread): AThrd {
+    const branchEntries = selectCurrentBranch(getEntries(rawThread));
+    const toolResults = buildToolResultMap(branchEntries);
+    const messages: (AthrdUserMessage | AthrdAssistantMessage)[] = [];
+    let currentModel: string | undefined;
+
+    for (const entry of branchEntries) {
+      if (entry.type === "model_change") {
+        const modelId = (entry as { modelId?: string }).modelId;
+        if (typeof modelId === "string" && modelId.length > 0) {
+          currentModel = modelId;
+        }
+        continue;
+      }
+
+      if (entry.type === "custom_message") {
+        const message = parseCustomMessageEntry(entry as PiCustomMessageEntry);
+        if (message) {
+          messages.push(message);
+        }
+        continue;
+      }
+
+      if (entry.type === "compaction") {
+        const compaction = entry as PiCompactionEntry;
+        const message = parseSummaryMessage(
+          compaction.id,
+          compaction.timestamp,
+          "Compaction",
+          compaction.summary,
+          currentModel
+        );
+        if (message) {
+          messages.push(message);
+        }
+        continue;
+      }
+
+      if (entry.type === "branch_summary") {
+        const branchSummary = entry as { id: string; timestamp: string; summary: string };
+        const message = parseSummaryMessage(
+          branchSummary.id,
+          branchSummary.timestamp,
+          "Branch summary",
+          branchSummary.summary,
+          currentModel
+        );
+        if (message) {
+          messages.push(message);
+        }
+        continue;
+      }
+
+      if (entry.type !== "message") {
+        continue;
+      }
+
+      const messageEntry = entry as PiMessageEntry;
+      const agentMessage = messageEntry.message;
+
+      switch (agentMessage.role) {
+        case "user": {
+          const parsedMessage = parseUserMessage(messageEntry);
+          if (parsedMessage) {
+            messages.push(parsedMessage);
+          }
+          break;
+        }
+        case "assistant": {
+          const parsedMessage = parseAssistantMessage(
+            messageEntry,
+            agentMessage,
+            toolResults,
+            currentModel
+          );
+          if (parsedMessage) {
+            messages.push(parsedMessage);
+          }
+          break;
+        }
+        case "toolResult":
+          break;
+        case "bashExecution":
+          messages.push(parseBashExecutionMessage(messageEntry, agentMessage));
+          break;
+        case "custom": {
+          const parsedMessage = parseCustomMessage(messageEntry, agentMessage);
+          if (parsedMessage) {
+            messages.push(parsedMessage);
+          }
+          break;
+        }
+        case "branchSummary": {
+          const parsedMessage = parseSummaryMessage(
+            messageEntry.id,
+            getMessageTimestamp(messageEntry, agentMessage),
+            "Branch summary",
+            agentMessage.summary,
+            currentModel
+          );
+          if (parsedMessage) {
+            messages.push(parsedMessage);
+          }
+          break;
+        }
+        case "compactionSummary": {
+          const compaction = agentMessage as PiCompactionSummaryMessage;
+          const parsedMessage = parseSummaryMessage(
+            messageEntry.id,
+            getMessageTimestamp(messageEntry, compaction),
+            "Compaction",
+            compaction.summary,
+            currentModel
+          );
+          if (parsedMessage) {
+            messages.push(parsedMessage);
+          }
+          break;
+        }
+      }
+    }
+
+    return { messages };
+  },
+};
+
+export default piParser;

--- a/apps/web/src/parsers/utils.ts
+++ b/apps/web/src/parsers/utils.ts
@@ -127,6 +127,14 @@ const TOOL_NAME_MAPPINGS: Record<IDE, Record<string, CanonicalToolName>> = {
     run_terminal_command: "terminal_command",
     todo_write: "todos",
   },
+  [IDE.PI]: {
+    read: "read_file",
+    write: "write_file",
+    edit: "replace",
+    bash: "terminal_command",
+    ls: "ls",
+    grep: "grep_search",
+  },
 };
 
 /**

--- a/apps/web/src/types/ide.ts
+++ b/apps/web/src/types/ide.ts
@@ -4,4 +4,5 @@ export enum IDE {
   CODEX = "codex",
   GEMINI = "gemini",
   CURSOR = "cursor",
+  PI = "pi",
 }

--- a/apps/web/src/types/pi.ts
+++ b/apps/web/src/types/pi.ts
@@ -1,5 +1,5 @@
 export interface PiThread {
-  sessionId: string;
+  sessionId?: string;
   id?: string;
   type: "session";
   version?: number;
@@ -101,6 +101,7 @@ export interface PiImageContent {
 export interface PiThinkingContent {
   type: "thinking";
   thinking: string;
+  thinkingSignature?: string;
 }
 
 export interface PiToolCallContent {
@@ -130,9 +131,11 @@ export interface PiAssistantMessage {
   api?: string;
   provider?: string;
   model?: string;
-  stopReason?: "stop" | "length" | "toolUse" | "error" | "aborted";
+  usage?: PiUsage;
+  stopReason?: PiStopReason;
   errorMessage?: string;
   timestamp?: number;
+  responseId?: string;
 }
 
 export interface PiToolResultMessage {
@@ -188,3 +191,28 @@ export type PiAgentMessage =
   | PiCustomMessage
   | PiBranchSummaryMessage
   | PiCompactionSummaryMessage;
+
+export type PiStopReason =
+  | "stop"
+  | "length"
+  | "toolUse"
+  | "error"
+  | "aborted"
+  | (string & {});
+
+export interface PiUsageCost {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+}
+
+export interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+  cost?: PiUsageCost;
+}

--- a/apps/web/src/types/pi.ts
+++ b/apps/web/src/types/pi.ts
@@ -1,0 +1,190 @@
+export interface PiThread {
+  sessionId: string;
+  id?: string;
+  type: "session";
+  version?: number;
+  timestamp: string;
+  cwd?: string;
+  parentSession?: string;
+  customTitle?: string;
+  updatedAt?: string;
+  entries?: PiEntry[];
+  messages?: PiEntry[];
+}
+
+interface PiEntryBase {
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+}
+
+export interface PiSessionInfoEntry extends PiEntryBase {
+  type: "session_info";
+  name?: string;
+}
+
+export interface PiModelChangeEntry extends PiEntryBase {
+  type: "model_change";
+  provider?: string;
+  modelId?: string;
+}
+
+export interface PiThinkingLevelChangeEntry extends PiEntryBase {
+  type: "thinking_level_change";
+  thinkingLevel?: string;
+}
+
+export interface PiCompactionEntry extends PiEntryBase {
+  type: "compaction";
+  summary: string;
+  firstKeptEntryId?: string;
+  tokensBefore?: number;
+  details?: unknown;
+}
+
+export interface PiBranchSummaryEntry extends PiEntryBase {
+  type: "branch_summary";
+  fromId: string;
+  summary: string;
+  details?: unknown;
+}
+
+export interface PiCustomEntry extends PiEntryBase {
+  type: "custom";
+  customType: string;
+  data?: unknown;
+}
+
+export interface PiCustomMessageEntry extends PiEntryBase {
+  type: "custom_message";
+  customType: string;
+  content: PiUserMessage["content"];
+  display?: boolean;
+  details?: unknown;
+}
+
+export interface PiLabelEntry extends PiEntryBase {
+  type: "label";
+  targetId: string;
+  label?: string;
+}
+
+export interface PiMessageEntry extends PiEntryBase {
+  type: "message";
+  message: PiAgentMessage;
+}
+
+export type PiEntry =
+  | PiSessionInfoEntry
+  | PiModelChangeEntry
+  | PiThinkingLevelChangeEntry
+  | PiCompactionEntry
+  | PiBranchSummaryEntry
+  | PiCustomEntry
+  | PiCustomMessageEntry
+  | PiLabelEntry
+  | PiMessageEntry
+  | (PiEntryBase & Record<string, unknown>);
+
+export interface PiTextContent {
+  type: "text";
+  text: string;
+  textSignature?: string;
+}
+
+export interface PiImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export interface PiThinkingContent {
+  type: "thinking";
+  thinking: string;
+}
+
+export interface PiToolCallContent {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export type PiUserContent = PiTextContent | PiImageContent;
+export type PiAssistantContent =
+  | PiTextContent
+  | PiImageContent
+  | PiThinkingContent
+  | PiToolCallContent;
+export type PiToolResultContent = PiTextContent | PiImageContent;
+
+export interface PiUserMessage {
+  role: "user";
+  content: string | PiUserContent[];
+  timestamp?: number;
+}
+
+export interface PiAssistantMessage {
+  role: "assistant";
+  content: PiAssistantContent[];
+  api?: string;
+  provider?: string;
+  model?: string;
+  stopReason?: "stop" | "length" | "toolUse" | "error" | "aborted";
+  errorMessage?: string;
+  timestamp?: number;
+}
+
+export interface PiToolResultMessage {
+  role: "toolResult";
+  toolCallId: string;
+  toolName: string;
+  content: PiToolResultContent[];
+  details?: unknown;
+  isError?: boolean;
+  timestamp?: number;
+}
+
+export interface PiBashExecutionMessage {
+  role: "bashExecution";
+  command: string;
+  output: string;
+  exitCode?: number;
+  cancelled?: boolean;
+  truncated?: boolean;
+  fullOutputPath?: string;
+  excludeFromContext?: boolean;
+  timestamp?: number;
+}
+
+export interface PiCustomMessage {
+  role: "custom";
+  customType: string;
+  content: string | PiUserContent[];
+  display?: boolean;
+  details?: unknown;
+  timestamp?: number;
+}
+
+export interface PiBranchSummaryMessage {
+  role: "branchSummary";
+  summary: string;
+  fromId: string;
+  timestamp?: number;
+}
+
+export interface PiCompactionSummaryMessage {
+  role: "compactionSummary";
+  summary: string;
+  tokensBefore?: number;
+  timestamp?: number;
+}
+
+export type PiAgentMessage =
+  | PiUserMessage
+  | PiAssistantMessage
+  | PiToolResultMessage
+  | PiBashExecutionMessage
+  | PiCustomMessage
+  | PiBranchSummaryMessage
+  | PiCompactionSummaryMessage;

--- a/packages/cli/src/commands/share.ts
+++ b/packages/cli/src/commands/share.ts
@@ -79,7 +79,7 @@ export function shareCommand(program: Command) {
     .option("-n, --number <count>", "Number of chats to display", "20")
     .option(
       "-i, --ide <ide>",
-      "Filter by IDE (vscode, gemini, claude, codex, cursor)",
+      "Filter by IDE (vscode, gemini, claude, codex, cursor, opencode, pi)",
     )
     .option("--vscode", "Filter by VS Code")
     .option("--gemini", "Filter by Gemini")
@@ -87,6 +87,7 @@ export function shareCommand(program: Command) {
     .option("--cursor", "Filter by Cursor")
     .option("--codex", "Filter by Codex")
     .option("--opencode", "Filter by OpenCode")
+    .option("--pi", "Filter by Pi")
     .option("--json <json>", "JSON payload from hook event")
     .option(
       "--mark",
@@ -102,6 +103,7 @@ export function shareCommand(program: Command) {
         if (options.cursor) filterIde = "cursor";
         if (options.codex) filterIde = "codex";
         if (options.opencode) filterIde = "opencode";
+        if (options.pi) filterIde = "pi";
 
         console.log(chalk.blue("📋 Finding AI chat threads...\n"));
 

--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -5,6 +5,7 @@ import { CodexProvider } from "./codex.js";
 import { CursorProvider } from "./cursor.js";
 import { GeminiProvider } from "./gemini.js";
 import { OpenCodeProvider } from "./opencode.js";
+import { PiProvider } from "./pi.js";
 
 export const providers: ChatProvider[] = [
 	new VSCodeProvider(),
@@ -13,6 +14,7 @@ export const providers: ChatProvider[] = [
 	new CursorProvider(),
 	new GeminiProvider(),
 	new OpenCodeProvider(),
+	new PiProvider(),
 ];
 
 export function getProvider(id: string): ChatProvider | undefined {
@@ -26,3 +28,4 @@ export * from "./codex.js";
 export * from "./cursor.js";
 export * from "./gemini.js";
 export * from "./opencode.js";
+export * from "./pi.js";

--- a/packages/cli/src/providers/pi.test.ts
+++ b/packages/cli/src/providers/pi.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { PiProvider } from "./pi.js";
+
+const tempDirs: string[] = [];
+const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  if (originalPiCodingAgentDir === undefined) {
+    delete process.env.PI_CODING_AGENT_DIR;
+  } else {
+    process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+  }
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("PiProvider", () => {
+  test("discovers Pi JSONL sessions and preserves entries for parsing", async () => {
+    const agentDir = makeTempDir("athrd-pi-agent-");
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+
+    const sessionDir = join(
+      agentDir,
+      "sessions",
+      "--Users-gregorymarcilhacy-code-athrd--",
+    );
+    mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = join(
+      sessionDir,
+      "2026-04-22T14-55-26-053Z_019db5b0-5765-740b-9c85-535e5009fd9b.jsonl",
+    );
+    const toolCallId =
+      "call_rXJ84iiJ2nNaJf1bkHDKpODq|fc_054902127f4391cf0169e8e16b66688197bc072334b9ecb9b7";
+
+    const entries = [
+      {
+        type: "session",
+        version: 3,
+        id: "019db5b0-5765-740b-9c85-535e5009fd9b",
+        timestamp: "2026-04-22T14:55:26.053Z",
+        cwd: "/Users/gregorymarcilhacy/code/athrd",
+      },
+      {
+        type: "model_change",
+        id: "621b9d57",
+        parentId: null,
+        timestamp: "2026-04-22T14:55:26.067Z",
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+      },
+      {
+        type: "thinking_level_change",
+        id: "afaf23a3",
+        parentId: "621b9d57",
+        timestamp: "2026-04-22T14:55:26.067Z",
+        thinkingLevel: "medium",
+      },
+      {
+        type: "message",
+        id: "3ed89b7c",
+        parentId: "afaf23a3",
+        timestamp: "2026-04-22T14:55:35.575Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "list the folders in ~/.pi/" }],
+          timestamp: 1776869735571,
+        },
+      },
+      {
+        type: "message",
+        id: "87fb6f5c",
+        parentId: "3ed89b7c",
+        timestamp: "2026-04-22T14:55:39.602Z",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "**Following command compliance**\n\nI need to run the folder listing with bash.",
+            },
+            {
+              type: "toolCall",
+              id: toolCallId,
+              name: "bash",
+              arguments: {
+                command:
+                  "find ~/.pi -maxdepth 1 -mindepth 1 -type d -print | sort",
+              },
+            },
+          ],
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          stopReason: "toolUse",
+          timestamp: 1776869735580,
+        },
+      },
+      {
+        type: "message",
+        id: "4097b33f",
+        parentId: "87fb6f5c",
+        timestamp: "2026-04-22T14:55:39.616Z",
+        message: {
+          role: "toolResult",
+          toolCallId,
+          toolName: "bash",
+          content: [{ type: "text", text: "/Users/gregorymarcilhacy/.pi/agent\n" }],
+          isError: false,
+          timestamp: 1776869739616,
+        },
+      },
+      {
+        type: "message",
+        id: "814bd521",
+        parentId: "4097b33f",
+        timestamp: "2026-04-22T14:55:41.482Z",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Folders in `~/.pi`:\n\n- `/Users/gregorymarcilhacy/.pi/agent`",
+            },
+          ],
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          stopReason: "stop",
+          timestamp: 1776869739618,
+        },
+      },
+    ];
+
+    writeFileSync(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    const provider = new PiProvider();
+    const sessions = await provider.findSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe("019db5b0-5765-740b-9c85-535e5009fd9b");
+    expect(sessions[0]?.customTitle).toBe("list the folders in ~/.pi/");
+    expect(sessions[0]?.requestCount).toBe(1);
+    expect(sessions[0]?.workspacePath).toBe("/Users/gregorymarcilhacy/code/athrd");
+
+    const parsed = await provider.parseSession(sessions[0]!);
+    expect(parsed.type).toBe("session");
+    expect(parsed.sessionId).toBe("019db5b0-5765-740b-9c85-535e5009fd9b");
+    expect(parsed.cwd).toBe("/Users/gregorymarcilhacy/code/athrd");
+    expect(parsed.entries).toHaveLength(6);
+    expect(parsed.entries[2].message.content[0].text).toBe(
+      "list the folders in ~/.pi/",
+    );
+    expect(parsed.entries[3].message.content[1]).toMatchObject({
+      type: "toolCall",
+      id: toolCallId,
+      name: "bash",
+    });
+    expect(parsed.entries[4].message).toMatchObject({
+      role: "toolResult",
+      toolCallId,
+      toolName: "bash",
+    });
+  });
+});

--- a/packages/cli/src/providers/pi.ts
+++ b/packages/cli/src/providers/pi.ts
@@ -1,0 +1,256 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ChatSession } from "../types/index.js";
+import { ChatProvider } from "./base.js";
+
+export class PiProvider implements ChatProvider {
+  readonly id = "pi";
+  readonly name = "Pi";
+
+  async findSessions(): Promise<ChatSession[]> {
+    const sessionsDir = this.getSessionsDir();
+    if (!fs.existsSync(sessionsDir)) {
+      return [];
+    }
+
+    const sessions: ChatSession[] = [];
+
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir)) {
+        const fullPath = path.join(dir, entry);
+        const stat = fs.statSync(fullPath);
+
+        if (stat.isDirectory()) {
+          walk(fullPath);
+          continue;
+        }
+
+        if (!entry.endsWith(".jsonl")) {
+          continue;
+        }
+
+        try {
+          const content = fs.readFileSync(fullPath, "utf-8");
+          const entries = this.parseJSONL(content);
+          const session = this.createSessionFromEntries(entries, fullPath);
+          if (session) {
+            sessions.push(session);
+          }
+        } catch {
+          // Skip unreadable or malformed session files.
+        }
+      }
+    };
+
+    walk(sessionsDir);
+    return sessions;
+  }
+
+  async parseSession(session: ChatSession): Promise<any> {
+    const content = fs.readFileSync(session.filePath, "utf-8");
+    const entries = this.parseJSONL(content);
+    const header = entries.find((entry) => entry?.type === "session") || {};
+    const bodyEntries = entries.filter((entry) => entry?.type !== "session");
+
+    return {
+      sessionId: session.sessionId,
+      ...header,
+      customTitle: session.customTitle,
+      updatedAt: new Date(session.lastMessageDate).toISOString(),
+      entries: bodyEntries,
+    };
+  }
+
+  private getSessionsDir(): string {
+    const agentDir =
+      process.env.PI_CODING_AGENT_DIR ||
+      path.join(os.homedir(), ".pi", "agent");
+
+    return path.join(agentDir, "sessions");
+  }
+
+  private createSessionFromEntries(
+    entries: any[],
+    filePath: string
+  ): ChatSession | null {
+    const header = entries.find((entry) => entry?.type === "session");
+    if (!header) {
+      return null;
+    }
+
+    let firstUserMessage: string | undefined;
+    let sessionName: string | undefined;
+    let requestCount = 0;
+    let earliestTimestamp = this.extractTimestamp(header);
+    let latestTimestamp = earliestTimestamp || 0;
+
+    for (const entry of entries) {
+      const timestamp = this.extractTimestamp(entry);
+      if (typeof timestamp === "number") {
+        earliestTimestamp =
+          typeof earliestTimestamp === "number"
+            ? Math.min(earliestTimestamp, timestamp)
+            : timestamp;
+        latestTimestamp = Math.max(latestTimestamp, timestamp);
+      }
+
+      if (entry?.type === "session_info" && typeof entry.name === "string") {
+        sessionName = entry.name;
+      }
+
+      if (entry?.type !== "message") {
+        continue;
+      }
+
+      const message = entry.message;
+      if (message?.role !== "user") {
+        continue;
+      }
+
+      const preview = this.extractTextFromContent(message.content);
+      if (!preview) {
+        continue;
+      }
+
+      requestCount++;
+      if (!firstUserMessage) {
+        firstUserMessage = preview.substring(0, 60);
+      }
+    }
+
+    if (requestCount === 0) {
+      return null;
+    }
+
+    const workspacePath =
+      typeof header.cwd === "string" && header.cwd.length > 0
+        ? header.cwd
+        : this.decodeWorkspacePath(filePath);
+    const workspaceName = workspacePath ? path.basename(workspacePath) : "Pi";
+    const creationDate = earliestTimestamp || latestTimestamp || Date.now();
+    const lastMessageDate = latestTimestamp || creationDate;
+
+    return {
+      sessionId: this.extractSessionId(header, filePath),
+      creationDate,
+      lastMessageDate,
+      customTitle: sessionName || firstUserMessage || "Pi Chat",
+      requestCount,
+      filePath,
+      source: this.id,
+      workspaceName,
+      workspacePath,
+      metadata: {
+        pi: {
+          version: header.version,
+          parentSession: header.parentSession,
+        },
+      },
+    };
+  }
+
+  private extractSessionId(header: any, filePath: string): string {
+    if (typeof header.id === "string" && header.id.length > 0) {
+      return header.id;
+    }
+
+    const basename = path.basename(filePath, ".jsonl");
+    const underscoreIndex = basename.lastIndexOf("_");
+    return underscoreIndex === -1
+      ? basename
+      : basename.substring(underscoreIndex + 1);
+  }
+
+  private extractTimestamp(entry: any): number | undefined {
+    const raw = entry?.message?.timestamp ?? entry?.timestamp;
+    if (!raw) {
+      return undefined;
+    }
+
+    const value =
+      typeof raw === "number"
+        ? raw < 1000000000000
+          ? raw * 1000
+          : raw
+        : new Date(raw).getTime();
+
+    return Number.isNaN(value) ? undefined : value;
+  }
+
+  private extractTextFromContent(content: unknown): string | undefined {
+    if (typeof content === "string") {
+      return this.normalizePreview(content);
+    }
+
+    if (!Array.isArray(content)) {
+      return undefined;
+    }
+
+    const text = content
+      .map((item) => {
+        if (
+          item &&
+          typeof item === "object" &&
+          "type" in item &&
+          (item as { type?: unknown }).type === "text" &&
+          "text" in item &&
+          typeof (item as { text?: unknown }).text === "string"
+        ) {
+          return (item as { text: string }).text;
+        }
+
+        if (
+          item &&
+          typeof item === "object" &&
+          "type" in item &&
+          (item as { type?: unknown }).type === "image"
+        ) {
+          return "[image]";
+        }
+
+        return null;
+      })
+      .filter((item): item is string => typeof item === "string" && item.length > 0)
+      .join("\n");
+
+    return this.normalizePreview(text);
+  }
+
+  private normalizePreview(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private decodeWorkspacePath(filePath: string): string | undefined {
+    const projectDir = path.basename(path.dirname(filePath));
+    if (!projectDir.startsWith("--") || !projectDir.endsWith("--")) {
+      return undefined;
+    }
+
+    const encoded = projectDir.slice(2, -2);
+    if (!encoded) {
+      return undefined;
+    }
+
+    return `/${encoded.replace(/-/g, "/")}`;
+  }
+
+  private parseJSONL(content: string): any[] {
+    return content
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is any => entry !== null);
+  }
+}


### PR DESCRIPTION
## Summary
- add Pi thread types and a web parser that converts Pi sessions into AThrd messages and tool calls
- register Pi in web parser detection, IDE metadata, model extraction, and thread header display
- add a CLI Pi provider plus share filtering support

## Validation
- bunx vitest run src/parsers/pi.test.ts
- bun test src/providers/pi.test.ts
- bun run build (packages/cli)
- bunx tsc --noEmit (apps/web)

Split out of #56 so the metadata sync API PR no longer carries the Pi implementation.