### PR TITLE
[codex] use hooks.json for codex hook install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,6 @@
         "athrd": "dist/index.js",
       },
       "dependencies": {
-        "@iarna/toml": "^2.2.5",
         "@octokit/auth-oauth-device": "^8.0.3",
         "@octokit/oauth-app": "^8.0.3",
         "@octokit/rest": "^22.0.1",
@@ -195,8 +194,6 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
-
-    "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,6 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
     "@octokit/auth-oauth-device": "^8.0.3",
     "@octokit/oauth-app": "^8.0.3",
     "@octokit/rest": "^22.0.1",

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { installCodexHook, uninstallCodexHook } from "./hooks.js";
+
+const tempDirs: string[] = [];
+const originalHome = process.env.HOME;
+let logSpy: ReturnType<typeof spyOn>;
+let errorSpy: ReturnType<typeof spyOn>;
+
+function makeTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function readHooksJson(home: string): any {
+    return JSON.parse(readFileSync(join(home, ".codex", "hooks.json"), "utf-8"));
+}
+
+beforeEach(() => {
+    const home = makeTempDir("athrd-codex-hooks-home-");
+    process.env.HOME = home;
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    process.env.HOME = originalHome;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+
+    while (tempDirs.length > 0) {
+        const dir = tempDirs.pop();
+        if (dir) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe("Codex hook install", () => {
+    test("writes a Stop hook to hooks.json", () => {
+        const home = process.env.HOME!;
+
+        installCodexHook();
+
+        const config = readHooksJson(home);
+        expect(config).toEqual({
+            hooks: {
+                Stop: [
+                    {
+                        hooks: [
+                            {
+                                type: "command",
+                                command: `bash '${join(home, ".athrd", "hook.sh")}' codex`,
+                                timeout: 30,
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+
+    test("preserves existing hooks and does not duplicate the athrd hook", () => {
+        const home = process.env.HOME!;
+        writeFileSync(
+            join(home, ".codex", "hooks.json"),
+            JSON.stringify(
+                {
+                    hooks: {
+                        Stop: [
+                            {
+                                hooks: [
+                                    {
+                                        type: "command",
+                                        command: "echo keep",
+                                    },
+                                ],
+                            },
+                        ],
+                        PreToolUse: [
+                            {
+                                matcher: "Bash",
+                                hooks: [{ type: "command", command: "echo bash" }],
+                            },
+                        ],
+                    },
+                },
+                null,
+                2,
+            ),
+        );
+
+        installCodexHook();
+        installCodexHook();
+
+        const config = readHooksJson(home);
+        const stopHooks = config.hooks.Stop.flatMap((group: any) => group.hooks);
+        const athrdHooks = stopHooks.filter((hook: any) =>
+            typeof hook.command === "string" &&
+            hook.command.includes("hook.sh") &&
+            hook.command.endsWith(" codex"),
+        );
+
+        expect(config.hooks.PreToolUse).toHaveLength(1);
+        expect(stopHooks.some((hook: any) => hook.command === "echo keep")).toBe(true);
+        expect(athrdHooks).toHaveLength(1);
+    });
+});
+
+describe("Codex hook uninstall", () => {
+    test("removes only the athrd Codex Stop hook", () => {
+        const home = process.env.HOME!;
+        writeFileSync(
+            join(home, ".codex", "hooks.json"),
+            JSON.stringify(
+                {
+                    hooks: {
+                        Stop: [
+                            {
+                                hooks: [
+                                    {
+                                        type: "command",
+                                        command: `bash '${join(home, ".athrd", "hook.sh")}' codex`,
+                                        timeout: 30,
+                                    },
+                                ],
+                            },
+                            {
+                                hooks: [
+                                    {
+                                        type: "command",
+                                        command: "echo keep",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                null,
+                2,
+            ),
+        );
+
+        uninstallCodexHook();
+
+        expect(readHooksJson(home)).toEqual({
+            hooks: {
+                Stop: [
+                    {
+                        hooks: [
+                            {
+                                type: "command",
+                                command: "echo keep",
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -3,19 +3,34 @@ import { Command } from "commander";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import toml from "@iarna/toml";
 import {
     installGlobalCommitMsgHook,
     uninstallGlobalCommitMsgHook,
 } from "../utils/git-hooks.js";
 
-const homedir = os.homedir();
-const athrdDir = path.join(homedir, ".athrd");
-const hookScriptPath = path.join(athrdDir, "hook.sh");
+function getAthrdDir() {
+    return path.join(getHomeDir(), ".athrd");
+}
 
-const claudeConfigPath = path.join(homedir, ".claude", "settings.json");
-const codexConfigPath = path.join(homedir, ".codex", "config.toml");
-const geminiConfigPath = path.join(homedir, ".gemini", "settings.json");
+function getHookScriptPath() {
+    return path.join(getAthrdDir(), "hook.sh");
+}
+
+function getClaudeConfigPath() {
+    return path.join(getHomeDir(), ".claude", "settings.json");
+}
+
+function getCodexHooksPath() {
+    return path.join(getHomeDir(), ".codex", "hooks.json");
+}
+
+function getGeminiConfigPath() {
+    return path.join(getHomeDir(), ".gemini", "settings.json");
+}
+
+function getHomeDir() {
+    return process.env.HOME || os.homedir();
+}
 
 const hookScriptContent = `#!/bin/bash
 PROVIDER=$1
@@ -23,7 +38,8 @@ PROVIDER=$1
 INPUT=$(cat)
 EVENT_JSON="$INPUT"
 
-# Codex sends hook data as the second argument, not stdin.
+# Most providers send hook JSON on stdin. Legacy Codex notify hooks sent
+# hook data as the second argument, so keep that fallback for older installs.
 if [ "$PROVIDER" = "codex" ] && [ -n "$2" ]; then
     EVENT_JSON="$2"
 fi
@@ -33,13 +49,15 @@ if [ -n "$EVENT_JSON" ]; then
 fi
 `;
 
-async function ensureAthrdDir() {
+function ensureAthrdDir() {
+    const athrdDir = getAthrdDir();
     if (!fs.existsSync(athrdDir)) {
         fs.mkdirSync(athrdDir, { recursive: true });
     }
 }
 
 function writeHookScript() {
+    const hookScriptPath = getHookScriptPath();
     ensureAthrdDir();
     fs.writeFileSync(hookScriptPath, hookScriptContent, { mode: 0o755 });
     console.log(
@@ -48,6 +66,7 @@ function writeHookScript() {
 }
 
 function removeHookScript() {
+    const hookScriptPath = getHookScriptPath();
     if (fs.existsSync(hookScriptPath)) {
         fs.unlinkSync(hookScriptPath);
         console.log(chalk.green(`✓ Hook script removed from ${hookScriptPath}`));
@@ -56,6 +75,8 @@ function removeHookScript() {
 
 function installClaudeHook() {
     try {
+        const claudeConfigPath = getClaudeConfigPath();
+        const hookScriptPath = getHookScriptPath();
         if (!fs.existsSync(claudeConfigPath)) {
             console.log(
                 chalk.yellow(`Claude config not found at ${claudeConfigPath}, skipping.`),
@@ -102,6 +123,7 @@ function installClaudeHook() {
 
 function uninstallClaudeHook() {
     try {
+        const claudeConfigPath = getClaudeConfigPath();
         if (!fs.existsSync(claudeConfigPath)) return;
 
         const content = fs.readFileSync(claudeConfigPath, "utf-8");
@@ -127,9 +149,52 @@ function uninstallClaudeHook() {
     }
 }
 
-function installCodexHook() {
+function isRecord(value: unknown): value is Record<string, any> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJsonObject(filePath: string): Record<string, any> {
+    if (!fs.existsSync(filePath)) {
+        return {};
+    }
+
+    const content = fs.readFileSync(filePath, "utf-8");
+    if (content.trim().length === 0) {
+        return {};
+    }
+
+    const config = JSON.parse(content);
+    if (!isRecord(config)) {
+        throw new Error(`${filePath} must contain a JSON object.`);
+    }
+
+    return config;
+}
+
+function writeJsonObject(filePath: string, value: Record<string, any>) {
+    fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function getCodexHookCommand() {
+    return `bash ${shellQuote(getHookScriptPath())} codex`;
+}
+
+function isAthrdCodexHook(hook: unknown): boolean {
+    if (!isRecord(hook) || hook.type !== "command" || typeof hook.command !== "string") {
+        return false;
+    }
+
+    return hook.command.includes("hook.sh") && /(^|[\s"'])codex($|[\s"'])/.test(hook.command);
+}
+
+export function installCodexHook() {
     try {
-        const codexDir = path.dirname(codexConfigPath);
+        const codexHooksPath = getCodexHooksPath();
+        const codexDir = path.dirname(codexHooksPath);
         if (!fs.existsSync(codexDir)) {
             console.log(
                 chalk.yellow(`Codex config dir not found at ${codexDir}, skipping.`),
@@ -137,16 +202,35 @@ function installCodexHook() {
             return;
         }
 
-        let config: any = {};
-        if (fs.existsSync(codexConfigPath)) {
-            const content = fs.readFileSync(codexConfigPath, "utf-8");
-            config = toml.parse(content);
+        const config = readJsonObject(codexHooksPath);
+
+        if (config.hooks === undefined) {
+            config.hooks = {};
+        } else if (!isRecord(config.hooks)) {
+            throw new Error(`${codexHooksPath} hooks must be an object.`);
         }
 
-        const newNotify = ["bash", hookScriptPath, "codex"];
-        if (!config.notify || JSON.stringify(config.notify) !== JSON.stringify(newNotify)) {
-            config.notify = newNotify;
-            fs.writeFileSync(codexConfigPath, toml.stringify(config));
+        if (config.hooks.Stop === undefined) {
+            config.hooks.Stop = [];
+        } else if (!Array.isArray(config.hooks.Stop)) {
+            throw new Error(`${codexHooksPath} hooks.Stop must be an array.`);
+        }
+
+        const hasHook = config.hooks.Stop.some((hookGroup: any) =>
+            Array.isArray(hookGroup?.hooks) && hookGroup.hooks.some(isAthrdCodexHook),
+        );
+
+        if (!hasHook) {
+            config.hooks.Stop.push({
+                hooks: [
+                    {
+                        type: "command",
+                        command: getCodexHookCommand(),
+                        timeout: 30,
+                    },
+                ],
+            });
+            writeJsonObject(codexHooksPath, config);
             console.log(chalk.green(`✓ Codex hook installed`));
         } else {
             console.log(chalk.blue(`ℹ Codex hook is already installed`));
@@ -156,16 +240,37 @@ function installCodexHook() {
     }
 }
 
-function uninstallCodexHook() {
+export function uninstallCodexHook() {
     try {
-        if (!fs.existsSync(codexConfigPath)) return;
+        const codexHooksPath = getCodexHooksPath();
+        if (!fs.existsSync(codexHooksPath)) return;
 
-        const content = fs.readFileSync(codexConfigPath, "utf-8");
-        const config: any = toml.parse(content);
+        const config = readJsonObject(codexHooksPath);
+        if (!isRecord(config.hooks) || !Array.isArray(config.hooks.Stop)) {
+            return;
+        }
 
-        if (config.notify && Array.isArray(config.notify) && config.notify.includes("codex")) {
-            delete config.notify;
-            fs.writeFileSync(codexConfigPath, toml.stringify(config));
+        let changed = false;
+        config.hooks.Stop = config.hooks.Stop.flatMap((hookGroup: any) => {
+            if (!isRecord(hookGroup) || !Array.isArray(hookGroup.hooks)) {
+                return [hookGroup];
+            }
+
+            const hooks = hookGroup.hooks.filter((hook: unknown) => !isAthrdCodexHook(hook));
+            if (hooks.length === hookGroup.hooks.length) {
+                return [hookGroup];
+            }
+
+            changed = true;
+            if (hooks.length === 0) {
+                return [];
+            }
+
+            return [{ ...hookGroup, hooks }];
+        });
+
+        if (changed) {
+            writeJsonObject(codexHooksPath, config);
             console.log(chalk.green(`✓ Codex hook removed`));
         }
     } catch (err) {
@@ -175,6 +280,8 @@ function uninstallCodexHook() {
 
 function installGeminiHook() {
     try {
+        const geminiConfigPath = getGeminiConfigPath();
+        const hookScriptPath = getHookScriptPath();
         if (!fs.existsSync(geminiConfigPath)) {
             console.log(
                 chalk.yellow(`Gemini config not found at ${geminiConfigPath}, skipping.`),
@@ -218,6 +325,7 @@ function installGeminiHook() {
 
 function uninstallGeminiHook() {
     try {
+        const geminiConfigPath = getGeminiConfigPath();
         if (!fs.existsSync(geminiConfigPath)) return;
 
         const content = fs.readFileSync(geminiConfigPath, "utf-8");


### PR DESCRIPTION
## Summary

Updates the CLI Codex hook installer to use `~/.codex/hooks.json` instead of writing `notify` into `~/.codex/config.toml`.

## Details

- Installs a documented `hooks.Stop` command hook for Codex.
- Preserves existing hook groups and removes only the athrd Codex hook on uninstall.
- Keeps the hook script compatible with stdin hook payloads while retaining the legacy second-argument fallback.
- Removes the now-unused `@iarna/toml` dependency.

## Validation

- `bun test packages/cli/src/commands/hooks.test.ts`
- `bun run --cwd packages/cli build`
- `bun test packages/cli/src`
- `git diff --check`
