### PR TITLE
[codex] Use Codex state title when sharing

### DIFF
--- a/packages/cli/src/commands/share.ts
+++ b/packages/cli/src/commands/share.ts
@@ -283,6 +283,9 @@ export function shareCommand(program: Command) {
                 githubUsername: userInfo.username,
                 githubRepo: githubRepo,
                 ide: provider.id, // Use provider ID as 'ide'
+                ...(session.customTitle && {
+                  title: session.customTitle,
+                }),
                 ...(commitHash && {
                   commitHash,
                 }),

--- a/packages/cli/src/providers/codex.test.ts
+++ b/packages/cli/src/providers/codex.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { CodexProvider } from "./codex.js";
 
 describe("CodexProvider", () => {
@@ -37,5 +41,65 @@ describe("CodexProvider", () => {
     expect(session).not.toBeNull();
     expect(session.customTitle).toBe("FOO\nBAR");
     expect(session.requestCount).toBe(1);
+  });
+
+  test("uses Codex state sqlite title when available", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "athrd-codex-"));
+    const stateDbPath = path.join(tmpDir, "state.sqlite");
+    const sessionId = "session_sqlite_title";
+    const previousStatePath = process.env.ATHRD_CODEX_STATE_SQLITE;
+
+    try {
+      const db = new Database(stateDbPath);
+      db.run("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)");
+      db.run("INSERT INTO threads (id, title) VALUES (?, ?)", [
+        "other_session",
+        "Wrong title",
+      ]);
+      db.run("INSERT INTO threads (id, title) VALUES (?, ?)", [
+        sessionId,
+        "SQLite title",
+      ]);
+      db.close();
+
+      process.env.ATHRD_CODEX_STATE_SQLITE = stateDbPath;
+
+      const provider = new CodexProvider() as any;
+      const session = provider.createSessionFromEntries(
+        [
+          {
+            type: "session_meta",
+            payload: {
+              id: sessionId,
+              cwd: "/tmp/workspace",
+            },
+            timestamp: "2026-03-02T20:45:10.000Z",
+          },
+          {
+            timestamp: "2026-03-02T20:45:11.971Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "fallback title" }],
+            },
+          },
+        ],
+        "/tmp/rollout.jsonl",
+      );
+
+      expect(provider.readThreadTitleFromSQLite(sessionId)).toBe(
+        "SQLite title",
+      );
+      expect(session?.customTitle).toBe("SQLite title");
+    } finally {
+      if (previousStatePath === undefined) {
+        delete process.env.ATHRD_CODEX_STATE_SQLITE;
+      } else {
+        process.env.ATHRD_CODEX_STATE_SQLITE = previousStatePath;
+      }
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/providers/codex.ts
+++ b/packages/cli/src/providers/codex.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -53,7 +54,7 @@ export class CodexProvider implements ChatProvider {
 
   private createSessionFromEntries(
     entries: any[],
-    filePath: string
+    filePath: string,
   ): ChatSession | null {
     let sessionId: string | undefined;
     let workspacePath: string | undefined;
@@ -119,12 +120,14 @@ export class CodexProvider implements ChatProvider {
     const lastMessageDate = latestTimestamp || creationDate;
 
     const metadata = codexMetadata ? { codex: codexMetadata } : undefined;
+    const resolvedSessionId = sessionId || path.basename(filePath, ".jsonl");
+    const stateTitle = this.readThreadTitleFromSQLite(resolvedSessionId);
 
     return {
-      sessionId: sessionId || path.basename(filePath, ".jsonl"),
+      sessionId: resolvedSessionId,
       creationDate,
       lastMessageDate,
-      customTitle: firstUserMessage || "Codex Chat",
+      customTitle: stateTitle || firstUserMessage || "Codex Chat",
       requestCount: messageCount,
       filePath,
       source: this.id,
@@ -132,6 +135,39 @@ export class CodexProvider implements ChatProvider {
       workspacePath,
       metadata,
     };
+  }
+
+  private readThreadTitleFromSQLite(threadId: string): string | undefined {
+    const stateDbPath =
+      process.env.ATHRD_CODEX_STATE_SQLITE ||
+      path.join(os.homedir(), ".codex", "state.sqlite");
+
+    if (!fs.existsSync(stateDbPath)) {
+      return undefined;
+    }
+
+    let db: Database | undefined;
+
+    try {
+      db = new Database(stateDbPath, { readonly: true, create: false });
+      const row = db
+        .query(
+          "SELECT title FROM threads WHERE id = ? AND title IS NOT NULL LIMIT 1",
+        )
+        .get(threadId) as { title?: unknown } | null;
+
+      if (typeof row?.title !== "string") {
+        return undefined;
+      }
+
+      const title = row.title.trim();
+      return title || undefined;
+    } catch {
+      // Codex state is best-effort metadata. Keep session discovery working.
+      return undefined;
+    } finally {
+      db?.close();
+    }
   }
 
   private extractTimestamp(entry: any): number | undefined {
@@ -149,9 +185,7 @@ export class CodexProvider implements ChatProvider {
     return Number.isNaN(value) ? undefined : value;
   }
 
-  private extractUserMessage(
-    entry: any
-  ): { preview?: string } | null {
+  private extractUserMessage(entry: any): { preview?: string } | null {
     if (!entry) {
       return null;
     }
@@ -212,7 +246,9 @@ export class CodexProvider implements ChatProvider {
             previews.push(preview);
           }
         } else if (item && typeof item === "object") {
-          const preview = this.extractTextFromContent(item.text ?? item.content);
+          const preview = this.extractTextFromContent(
+            item.text ?? item.content,
+          );
           if (preview) {
             previews.push(preview);
           }


### PR DESCRIPTION
## Summary

- Read Codex session titles from `~/.codex/state.sqlite` using Bun SQLite.
- Prefer the persisted Codex `threads.title` value for share labels and gist descriptions.
- Include the resolved title in uploaded `__athrd.title` metadata so the web app can display it directly.

## Impact

Shared Codex threads now use the stored Codex session title when available, while preserving the existing first-user-message fallback when the local state database is missing or unreadable.

## Validation

- `bun run --cwd packages/cli build`
- `bun test packages/cli/src`