### PR TITLE
[codex] Use Claude AI title for sharing

### DIFF
--- a/packages/cli/src/providers/claude.test.ts
+++ b/packages/cli/src/providers/claude.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ClaudeCodeProvider } from "./claude.js";
+
+const tempDirs: string[] = [];
+const originalHome = process.env.HOME;
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeJSONL(filePath: string, entries: any[]): void {
+  writeFileSync(
+    filePath,
+    entries.map((entry) => JSON.stringify(entry)).join("\n"),
+    "utf-8",
+  );
+}
+
+beforeEach(() => {
+  const home = makeTempDir("athrd-claude-home-");
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("ClaudeCodeProvider", () => {
+  test("uses Claude ai-title events as the thread title", async () => {
+    const sessionId = "6fb5abb6-0549-4dec-97f3-cedd89fd17aa";
+    const projectDir = join(
+      process.env.HOME!,
+      ".claude",
+      "projects",
+      "-Users-test-code-athrd",
+    );
+    mkdirSync(projectDir, { recursive: true });
+
+    const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+    writeJSONL(sessionFile, [
+      {
+        type: "summary",
+        summary: "Fallback summary",
+      },
+      {
+        type: "ai-title",
+        aiTitle: "Fix unknown command error message",
+        sessionId,
+      },
+      {
+        type: "user",
+        sessionId,
+        uuid: "user-1",
+        timestamp: "2026-04-28T17:00:00.000Z",
+        message: {
+          role: "user",
+          content: "Why does this command say unknown command?",
+        },
+      },
+      {
+        type: "assistant",
+        sessionId,
+        uuid: "assistant-1",
+        timestamp: "2026-04-28T17:01:00.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-3-5-sonnet-20241022",
+          content: [{ type: "text", text: "I'll check the command parser." }],
+        },
+      },
+    ]);
+
+    const provider = new ClaudeCodeProvider();
+    const sessions = await provider.findSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe(sessionId);
+    expect(sessions[0]?.customTitle).toBe(
+      "Fix unknown command error message",
+    );
+    expect(sessions[0]?.workspacePath).toBe("/Users/test/code/athrd");
+
+    const parsed = await provider.parseSession(sessions[0]!);
+    expect(parsed.customTitle).toBe("Fix unknown command error message");
+  });
+});

--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -4,12 +4,16 @@ import * as path from "path";
 import { ChatSession } from "../types/index.js";
 import { ChatProvider } from "./base.js";
 
+function getHomeDir(): string {
+  return process.env.HOME || os.homedir();
+}
+
 export class ClaudeCodeProvider implements ChatProvider {
   readonly id = "claude";
   readonly name = "Claude";
 
   async findSessions(): Promise<ChatSession[]> {
-    const claudeProjectsPath = path.join(os.homedir(), ".claude", "projects");
+    const claudeProjectsPath = path.join(getHomeDir(), ".claude", "projects");
 
     if (!fs.existsSync(claudeProjectsPath)) {
       return [];
@@ -45,7 +49,10 @@ export class ClaudeCodeProvider implements ChatProvider {
               const fileContent = fs.readFileSync(filePath, "utf-8");
               const lines = fileContent.split("\n");
 
+              const sessionId = file.replace(".jsonl", "");
+
               // Parse JSONL to find session metadata
+              let aiTitle: string | undefined;
               let summary: string | undefined;
               let lastMessageDate: number = 0;
               let messageCount = 0;
@@ -59,6 +66,14 @@ export class ClaudeCodeProvider implements ChatProvider {
                     // Get summary if available
                     if (entry.type === "summary" && !summary) {
                       summary = entry.summary;
+                    }
+
+                    // Claude Code stores the generated thread title in ai-title events.
+                    if (entry.type === "ai-title") {
+                      const title = this.extractAiTitle([entry], sessionId);
+                      if (title) {
+                        aiTitle = title;
+                      }
                     }
 
                     // Capture first user message as fallback for title
@@ -109,11 +124,11 @@ export class ClaudeCodeProvider implements ChatProvider {
                   .pop();
               }
 
-              // Use summary if available, otherwise use first user message, otherwise default
-              const title = summary || firstUserMessage || "Claude Chat";
+              // Use Claude's generated title if available, then fall back to older metadata.
+              const title = aiTitle || summary || firstUserMessage || "Claude Chat";
 
               sessions.push({
-                sessionId: file.replace(".jsonl", ""),
+                sessionId,
                 creationDate: lastMessageDate,
                 lastMessageDate,
                 customTitle: title,
@@ -123,7 +138,7 @@ export class ClaudeCodeProvider implements ChatProvider {
                 workspaceName,
                 workspacePath,
                 metadata: {
-                  agentFiles: agentFiles.get(file.replace(".jsonl", "")) || [],
+                  agentFiles: agentFiles.get(sessionId) || [],
                 },
               });
             } catch (error) {
@@ -235,8 +250,38 @@ export class ClaudeCodeProvider implements ChatProvider {
 
     return {
       sessionId,
+      customTitle: this.extractAiTitle(jsonlEntries, sessionId),
       requests,
     };
+  }
+
+  private extractAiTitle(
+    jsonlEntries: any[],
+    sessionId?: string,
+  ): string | undefined {
+    let aiTitle: string | undefined;
+
+    for (const entry of jsonlEntries) {
+      if (entry?.type !== "ai-title" || typeof entry.aiTitle !== "string") {
+        continue;
+      }
+
+      if (
+        sessionId &&
+        sessionId !== "unknown" &&
+        typeof entry.sessionId === "string" &&
+        entry.sessionId !== sessionId
+      ) {
+        continue;
+      }
+
+      const title = entry.aiTitle.trim();
+      if (title) {
+        aiTitle = title;
+      }
+    }
+
+    return aiTitle;
   }
 
   private async mergeAgentFilesIntoSession(


### PR DESCRIPTION
## Summary

Updates the CLI Claude provider so `athrd share --claude` uses Claude Code `ai-title` JSONL events as the thread title. The generated `aiTitle` is now preferred over legacy `summary` and first-user-message fallbacks, which makes shared gist metadata and descriptions match Claude generated thread titles.

## Root Cause

Claude Code stores generated thread titles in JSONL records like `type: "ai-title"`, but the CLI session discovery only looked at `summary` and user-message fallbacks.

## Validation

- `bun run --cwd packages/cli build`
- `bun test packages/cli/src`

---
# Agent Session(s)
- https://athrd.com/threads/53b9aaa6a79a7f3ed6cefcb44baeb23e
- https://athrd.com/threads/a63020d781caa96b38c7d7e2d85f7699
- https://athrd.com/threads/eb7e47a531ed6d6779e357df22e79591