### PR TITLE
[codex] Add CLI session secret obfuscation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ To share sessions manually:
 athrd share
 ```
 
+Uploaded sessions are secret-obfuscated: detected API keys, tokens, passwords,
+private keys, credential-bearing URLs, and secret-like environment variables are
+replaced with `********` before upload.
+
 ### GitHub Action: sync athrd links into PR body
 
 If you want repo-owned automation (no GitHub App install), add this workflow to the target repository:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,9 @@ Share sessions manually:
 athrd share
 ```
 
+Session uploads replace detected secrets with `********` before they are written
+to Gists or signed upload storage.
+
 Log out and clear stored credentials:
 
 ```bash

--- a/packages/cli/src/commands/share.ts
+++ b/packages/cli/src/commands/share.ts
@@ -34,6 +34,7 @@ import {
 } from "../utils/ingest-client.js";
 import { appendAthrdUrlMarker } from "../utils/marker.js";
 import { maybeBackfillHookDrivenCommit } from "../utils/hook-share-backfill.js";
+import { obfuscateSessionContent } from "../utils/secret-obfuscation.js";
 import {
   getGistIdForThread,
   upsertThreadGistMapping,
@@ -441,7 +442,22 @@ export function shareCommand(program: Command) {
               },
             };
 
-            const content = injectAthrdMetadata(artifact, athrdMetadata);
+            let content = injectAthrdMetadata(artifact, athrdMetadata);
+            const obfuscated = obfuscateSessionContent(
+              content,
+              artifact.format,
+            );
+            content = obfuscated.content;
+
+            if (obfuscated.redactionCount > 0) {
+              console.log(
+                chalk.dim(
+                  `  • Obfuscated ${obfuscated.redactionCount} potential secret(s) in ${
+                    session.title || session.sessionId
+                  }`,
+                ),
+              );
+            }
             const fileName = artifact.fileName;
             let actionLabel: string;
             let athrdUrl: string;

--- a/packages/cli/src/utils/secret-obfuscation.test.ts
+++ b/packages/cli/src/utils/secret-obfuscation.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  obfuscateSessionContent,
+  obfuscateText,
+  SECRET_MASK,
+} from "./secret-obfuscation.js";
+
+describe("secret obfuscation", () => {
+  test("masks secret-like JSON fields and preserves non-secret metadata", () => {
+    const content = JSON.stringify({
+      __athrd: {
+        thread: {
+          id: "session-1",
+          source: "codex",
+        },
+        commit: {
+          sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        },
+      },
+      env: {
+        OPENAI_API_KEY: "sk-proj-1234567890abcdefghijklmnopqrstuvwxyz",
+        GITHUB_TOKEN: "not-a-known-token-format",
+        INPUT_TOKENS: 42,
+      },
+      messages: [
+        {
+          role: "user",
+          content:
+            "run with DATABASE_URL=postgres://user:pass@localhost/app and Authorization: Bearer github_pat_1234567890abcdefghijklmnopqrstuvwxyzABCDEF",
+        },
+      ],
+    });
+
+    const result = obfuscateSessionContent(content, "json");
+    const parsed = JSON.parse(result.content);
+
+    expect(parsed.__athrd.thread.id).toBe("session-1");
+    expect(parsed.__athrd.commit.sha).toBe(
+      "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    );
+    expect(parsed.env.OPENAI_API_KEY).toBe(SECRET_MASK);
+    expect(parsed.env.GITHUB_TOKEN).toBe(SECRET_MASK);
+    expect(parsed.env.INPUT_TOKENS).toBe(42);
+    expect(parsed.messages[0].content).toContain(`DATABASE_URL=${SECRET_MASK}`);
+    expect(parsed.messages[0].content).toContain(
+      `Authorization: Bearer ${SECRET_MASK}`,
+    );
+    expect(parsed.messages[0].content).not.toContain("postgres://user:pass");
+    expect(parsed.messages[0].content).not.toContain("github_pat_");
+    expect(result.redactionCount).toBeGreaterThanOrEqual(4);
+  });
+
+  test("masks JSONL rows without changing row count", () => {
+    const content = [
+      JSON.stringify({
+        type: "athrd_metadata",
+        __athrd: {
+          thread: {
+            id: "session-1",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        usage: {
+          total_tokens: 100,
+        },
+        message: {
+          content: [
+            {
+              type: "input_text",
+              text: "export ANTHROPIC_API_KEY='sk-ant-api03-1234567890abcdefghijklmnopqrstuvwxyz'",
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+
+    const result = obfuscateSessionContent(content, "jsonl");
+    const rows = result.content.trim().split("\n").map((line) => JSON.parse(line));
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].__athrd.thread.id).toBe("session-1");
+    expect(rows[1].usage.total_tokens).toBe(100);
+    expect(rows[1].message.content[0].text).toBe(
+      `export ANTHROPIC_API_KEY='${SECRET_MASK}'`,
+    );
+  });
+
+  test("masks common secrets in plain text fallback content", () => {
+    const stripeSecret = ["sk", "live", "1234567890abcdefghijklmnop"].join("_");
+    const text = [
+      `STRIPE_SECRET_KEY=${stripeSecret}`,
+      "npm token npm_1234567890abcdefghijklmnopqrstuvwxyz",
+      "private key:",
+      "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "abc123",
+      "-----END OPENSSH PRIVATE KEY-----",
+    ].join("\n");
+
+    const result = obfuscateText(text);
+
+    expect(result.content).toContain(`STRIPE_SECRET_KEY=${SECRET_MASK}`);
+    expect(result.content).toContain(`npm token ${SECRET_MASK}`);
+    expect(result.content).toContain(`private key:\n${SECRET_MASK}`);
+    expect(result.content).not.toContain("sk_live_");
+    expect(result.content).not.toContain("npm_");
+    expect(result.content).not.toContain("abc123");
+  });
+});

--- a/packages/cli/src/utils/secret-obfuscation.ts
+++ b/packages/cli/src/utils/secret-obfuscation.ts
@@ -1,0 +1,279 @@
+export const SECRET_MASK = "********";
+
+export interface SecretObfuscationResult {
+  content: string;
+  redactionCount: number;
+}
+
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+interface ObfuscateValueResult {
+  value: JsonValue;
+  redactionCount: number;
+}
+
+const TOKEN_COUNT_KEY_PATTERN =
+  /^(?:(?:input|output|prompt|completion|cached|total|reasoning)_)?tokens?(?:_count)?$/;
+
+const NON_SECRET_KEY_PATTERN =
+  /^(?:token_count|tokens_count|input_tokens|output_tokens|prompt_tokens|completion_tokens|cached_tokens|total_tokens|reasoning_tokens|key|public_key)$/;
+
+const SECRET_KEY_COMPACT_PATTERNS = [
+  "apikey",
+  "authkey",
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "sessiontoken",
+  "clientsecret",
+  "webhooksecret",
+  "signingsecret",
+  "privatekey",
+  "secretkey",
+  "accesskey",
+  "databaseurl",
+  "postgresurl",
+  "postgresqlurl",
+  "mysqlurl",
+  "redisurl",
+  "mongodburi",
+  "mongoaturi",
+  "connectionstring",
+];
+
+const SECRET_KEY_WORDS = new Set([
+  "authorization",
+  "credential",
+  "credentials",
+  "jwt",
+  "passwd",
+  "password",
+  "pwd",
+  "secret",
+  "token",
+]);
+
+const KNOWN_SECRET_VALUE_PATTERNS = [
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\bgh[opsru]_[A-Za-z0-9_]{20,}\b/g,
+  /\bsk-(?:proj-|ant-|ant-api\d+-)?[A-Za-z0-9_-]{20,}\b/g,
+  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bASIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  /\bnpm_[A-Za-z0-9]{20,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+];
+
+const PRIVATE_KEY_BLOCK_PATTERN =
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
+
+const URL_CREDENTIAL_PATTERN =
+  /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi;
+
+const AUTH_HEADER_PATTERN =
+  /\b(Authorization\s*[:=]\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9._~+/=-]{12,})/gi;
+
+const BEARER_TOKEN_PATTERN =
+  /\b(Bearer|Basic|Token)\s+([A-Za-z0-9._~+/=-]{20,})/gi;
+
+const QUOTED_ASSIGNMENT_PATTERN =
+  /\b([A-Za-z_][A-Za-z0-9_.-]{1,80})(\s*[:=]\s*)(["'])([^"'\r\n]{3,})\3/g;
+
+const UNQUOTED_ASSIGNMENT_PATTERN =
+  /\b([A-Za-z_][A-Za-z0-9_.-]{1,80})(\s*[:=]\s*)([^\s,;'"`]{8,})/g;
+
+export function obfuscateSessionContent(
+  content: string,
+  format: "json" | "jsonl",
+): SecretObfuscationResult {
+  try {
+    if (format === "json") {
+      const parsed = JSON.parse(content) as JsonValue;
+      const result = obfuscateJsonValue(parsed);
+      return {
+        content: `${JSON.stringify(result.value, null, 2)}\n`,
+        redactionCount: result.redactionCount,
+      };
+    }
+
+    const sourceRows = content.split(/\r?\n/).filter((line) => line.trim());
+    const outputRows: string[] = [];
+    let redactionCount = 0;
+
+    for (const row of sourceRows) {
+      const parsed = JSON.parse(row) as JsonValue;
+      const result = obfuscateJsonValue(parsed);
+      redactionCount += result.redactionCount;
+      outputRows.push(JSON.stringify(result.value));
+    }
+
+    return {
+      content: `${outputRows.join("\n")}\n`,
+      redactionCount,
+    };
+  } catch {
+    return obfuscateText(content);
+  }
+}
+
+function obfuscateJsonValue(
+  value: JsonValue,
+  keyName?: string,
+): ObfuscateValueResult {
+  if (keyName && isSecretKeyName(keyName) && value !== null) {
+    return {
+      value: SECRET_MASK,
+      redactionCount: 1,
+    };
+  }
+
+  if (typeof value === "string") {
+    const result = obfuscateText(value);
+    return {
+      value: result.content,
+      redactionCount: result.redactionCount,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    let redactionCount = 0;
+    const values = value.map((item) => {
+      const result = obfuscateJsonValue(item);
+      redactionCount += result.redactionCount;
+      return result.value;
+    });
+
+    return { value: values, redactionCount };
+  }
+
+  if (value && typeof value === "object") {
+    let redactionCount = 0;
+    const record: { [key: string]: JsonValue } = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const result = obfuscateJsonValue(nestedValue, key);
+      redactionCount += result.redactionCount;
+      record[key] = result.value;
+    }
+
+    return { value: record, redactionCount };
+  }
+
+  return { value, redactionCount: 0 };
+}
+
+export function obfuscateText(content: string): SecretObfuscationResult {
+  let redactionCount = 0;
+  let output = content.replace(PRIVATE_KEY_BLOCK_PATTERN, () => {
+    redactionCount++;
+    return SECRET_MASK;
+  });
+
+  output = output.replace(
+    AUTH_HEADER_PATTERN,
+    (_match, prefix: string, scheme: string) => {
+      redactionCount++;
+      return `${prefix}${scheme} ${SECRET_MASK}`;
+    },
+  );
+
+  output = output.replace(
+    QUOTED_ASSIGNMENT_PATTERN,
+    (
+      match: string,
+      key: string,
+      separator: string,
+      quote: string,
+      value: string,
+    ) => {
+      if (!isSecretKeyName(key) || value === SECRET_MASK) {
+        return match;
+      }
+
+      redactionCount++;
+      return `${key}${separator}${quote}${SECRET_MASK}${quote}`;
+    },
+  );
+
+  output = output.replace(
+    UNQUOTED_ASSIGNMENT_PATTERN,
+    (match: string, key: string, separator: string, value: string) => {
+      if (!isSecretKeyName(key) || value === SECRET_MASK) {
+        return match;
+      }
+
+      redactionCount++;
+      return `${key}${separator}${SECRET_MASK}`;
+    },
+  );
+
+  output = output.replace(
+    URL_CREDENTIAL_PATTERN,
+    (_match, protocol: string) => {
+      redactionCount++;
+      return `${protocol}${SECRET_MASK}@`;
+    },
+  );
+
+  output = output.replace(
+    BEARER_TOKEN_PATTERN,
+    (match: string, scheme: string, token: string) => {
+      if (token === SECRET_MASK) {
+        return match;
+      }
+
+      redactionCount++;
+      return `${scheme} ${SECRET_MASK}`;
+    },
+  );
+
+  for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
+    output = output.replace(pattern, (match) => {
+      if (match === SECRET_MASK) {
+        return match;
+      }
+
+      redactionCount++;
+      return SECRET_MASK;
+    });
+  }
+
+  return {
+    content: output,
+    redactionCount,
+  };
+}
+
+function isSecretKeyName(key: string): boolean {
+  const normalized = normalizeKeyName(key);
+  if (!normalized || NON_SECRET_KEY_PATTERN.test(normalized)) {
+    return false;
+  }
+
+  if (TOKEN_COUNT_KEY_PATTERN.test(normalized)) {
+    return false;
+  }
+
+  const compact = normalized.replace(/_/g, "");
+  if (SECRET_KEY_COMPACT_PATTERNS.some((pattern) => compact.includes(pattern))) {
+    return true;
+  }
+
+  return normalized.split("_").some((word) => SECRET_KEY_WORDS.has(word));
+}
+
+function normalizeKeyName(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+}


### PR DESCRIPTION
## Summary

Adds CLI-side secret obfuscation before session artifacts are uploaded to Gists or signed upload storage.

## Details

- Adds structured JSON/JSONL obfuscation that preserves valid session artifact formats while replacing likely secrets with `********`.
- Detects common secret fields and values, including API keys, tokens, passwords, private key blocks, authorization headers, credential URLs, and secret-like environment variables.
- Wires the obfuscation step into `athrd share` unconditionally before any upload path.
- Documents that uploaded sessions are obfuscated before storage.

## Validation

- `bun test packages/cli/src/utils/secret-obfuscation.test.ts`
- `bun run --cwd packages/cli build`
- `bun test packages/cli/src`
- `bun packages/cli/src/index.ts share --help` confirmed no opt-out flag is exposed.

---
# Agent Session(s)
- https://www.athrd.com/threads/0d09bcab21e6c4e2cc596e8c6b7bd7da
- https://www.athrd.com/threads/7b8a0275f074dc161365fe371f317f01

- https://www.athrd.com/threads/0d09bcab21e6c4e2cc596e8c6b7bd7da
- https://www.athrd.com/threads/7b8a0275f074dc161365fe371f317f01